### PR TITLE
fix: unblock vercel builds

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,6 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
 import AppShell from "@/components/AppShell"; // Import AppShell
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "Money Flow",
@@ -17,7 +14,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${inter.className} bg-gray-50`}>
+      <body className="bg-gray-50">
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/src/app/shops/ShopsView.tsx
+++ b/src/app/shops/ShopsView.tsx
@@ -1,192 +1,351 @@
-diff --git a/src/app/shops/ShopsView.tsx b/src/app/shops/ShopsView.tsx
-index 1cdbd3ff766a14472123d3fa4f75d5829dfe1964..9d3171cbfe88306f28854aa75d8ac577e7231bea 100644
---- a/src/app/shops/ShopsView.tsx
-+++ b/src/app/shops/ShopsView.tsx
-@@ -1,34 +1,35 @@
- "use client";
- 
--import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
-+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
- 
- import Tooltip from "@/components/Tooltip";
- import RemoteImage from "@/components/RemoteImage";
- import { ClearIcon } from "@/components/Icons";
- import { createTranslator, isTranslationKey } from "@/lib/i18n";
- import { useAppShell } from "@/components/AppShellProvider";
-+import AddShopModal from "@/components/shops/AddShopModal";
- 
- import type { Shop } from "../transactions/add/formData";
- 
- type ShopsViewProps = {
-   shops: Shop[];
-   errorMessage?: string;
- };
- 
- type TypeFilter = "all" | string;
- 
- type ShopRecord = Shop & { notes?: string | null };
- 
- const formatCreatedAt = (value: string | null | undefined) => {
-   if (!value) {
-     return "-";
-   }
-   const date = new Date(value);
-   if (Number.isNaN(date.getTime())) {
-     return "-";
-   }
-   return new Intl.DateTimeFormat("en-US", {
-     year: "numeric",
-     month: "short",
-     day: "numeric",
-   }).format(date);
-diff --git a/src/app/shops/ShopsView.tsx b/src/app/shops/ShopsView.tsx
-index 1cdbd3ff766a14472123d3fa4f75d5829dfe1964..9d3171cbfe88306f28854aa75d8ac577e7231bea 100644
---- a/src/app/shops/ShopsView.tsx
-+++ b/src/app/shops/ShopsView.tsx
-@@ -413,140 +414,34 @@ export default function ShopsView({ shops, errorMessage }: ShopsViewProps) {
-                               className="inline-flex items-center justify-center rounded-md border border-red-200 bg-white px-2 py-1 text-[11px] font-medium text-red-600 transition hover:bg-red-50"
-                             >
-                               Delete
-                             </button>
-                           </div>
-                         </div>
-                         <dl className="space-y-1 text-xs text-gray-600">
-                           <div className="flex items-center justify-between">
-                             <dt className="font-medium text-gray-500">{t("shops.fields.type")}</dt>
-                             <dd>{displayType}</dd>
-                           </div>
-                           <div className="flex items-center justify-between">
-                             <dt className="font-medium text-gray-500">{t("shops.fields.created")}</dt>
-                             <dd>{formatCreatedAt(shop.created_at ?? null)}</dd>
-                           </div>
-                         </dl>
-                       </div>
-                     );
-                   })}
-                 </div>
-               )}
-             </div>
-           </div>
-         </div>
-       </div>
--      {isAddModalOpen ? (
--        <AddShopModal
--          onClose={() => setAddModalOpen(false)}
--          onCreate={handleCreateShop}
--          onNavigate={handleNavigateToTransactions}
--        />
--      ) : null}
--    </div>
--  );
--}
--
--type AddShopModalProps = {
--  onClose: () => void;
--  onCreate: (values: { name: string; type?: string; notes?: string | null }) => void;
--  onNavigate: () => void;
--};
--
--function AddShopModal({ onClose, onCreate, onNavigate }: AddShopModalProps) {
--  const [name, setName] = useState("");
--  const [type, setType] = useState("");
--  const [notes, setNotes] = useState("");
--
--  const handleSubmit = useCallback(
--    (event: FormEvent<HTMLFormElement>) => {
--      event.preventDefault();
--      const trimmedName = name.trim();
--      if (!trimmedName) {
--        return;
--      }
--      onCreate({
--        name: trimmedName,
--        type: type.trim() || undefined,
--        notes: notes.trim() ? notes.trim() : null,
--      });
--      setName("");
--      setType("");
--      setNotes("");
--    },
--    [name, notes, onCreate, type]
--  );
--
--  return (
--    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4 py-6">
--      <div className="absolute inset-0" onClick={onClose} aria-hidden="true" />
--      <div className="relative z-10 w-full max-w-lg overflow-hidden rounded-xl bg-white shadow-2xl">
--        <div className="flex items-center justify-between border-b border-gray-200 bg-gray-50 px-6 py-4">
--          <h2 className="text-lg font-semibold text-gray-900">Add new shop</h2>
--          <button
--            type="button"
--            onClick={onClose}
--            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-600 transition hover:bg-gray-100"
--            aria-label="Close"
--          >
--            ×
--          </button>
--        </div>
--        <form onSubmit={handleSubmit} className="space-y-4 p-6">
--          <div className="space-y-1">
--            <label className="text-sm font-medium text-gray-700" htmlFor="shop-name-input">
--              Name
--            </label>
--            <input
--              id="shop-name-input"
--              value={name}
--              onChange={(event) => setName(event.target.value)}
--              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
--              placeholder="Enter shop name"
--              required
--            />
--          </div>
--          <div className="space-y-1">
--            <label className="text-sm font-medium text-gray-700" htmlFor="shop-type-input">
--              Type
--            </label>
--            <input
--              id="shop-type-input"
--              value={type}
--              onChange={(event) => setType(event.target.value)}
--              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
--              placeholder="e.g. ecommerce, bank"
--            />
--          </div>
--          <div className="space-y-1">
--            <label className="text-sm font-medium text-gray-700" htmlFor="shop-notes-input">
--              Notes
--            </label>
--            <textarea
--              id="shop-notes-input"
--              value={notes}
--              onChange={(event) => setNotes(event.target.value)}
--              rows={3}
--              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
--              placeholder="Additional details"
--            />
--          </div>
--          <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:justify-end">
--            <button
--              type="submit"
--              className="inline-flex items-center justify-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700"
--            >
--              Create shop
--            </button>
--            <button
--              type="button"
--              onClick={onNavigate}
--              className="inline-flex items-center justify-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:bg-gray-100"
--            >
--              Go to transactions
--            </button>
--          </div>
--        </form>
--      </div>
-+      <AddShopModal
-+        open={isAddModalOpen}
-+        onClose={() => setAddModalOpen(false)}
-+        onCreate={handleCreateShop}
-+        onNavigateToTransactions={handleNavigateToTransactions}
-+      />
-     </div>
-   );
- }
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import Tooltip from "@/components/Tooltip";
+import RemoteImage from "@/components/RemoteImage";
+import { ClearIcon } from "@/components/Icons";
+import { createTranslator, isTranslationKey } from "@/lib/i18n";
+import { useAppShell } from "@/components/AppShellProvider";
+import AddShopModal from "@/components/shops/AddShopModal";
+
+import type { Shop } from "../transactions/add/formData";
+
+type ShopsViewProps = {
+  shops: Shop[];
+  errorMessage?: string;
+  returnTo?: string;
+  shouldOpenModal?: boolean;
+};
+
+type TypeFilter = "all" | string;
+
+type ShopRecord = Shop & { notes?: string | null };
+
+const formatCreatedAt = (value: string | null | undefined) => {
+  if (!value) {
+    return "-";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "-";
+  }
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+};
+
+const normalize = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .trim();
+
+const getTypeLabel = (value: string | null | undefined, t: ReturnType<typeof createTranslator>) => {
+  if (!value) {
+    return "-";
+  }
+  if (isTranslationKey(value)) {
+    return t(value);
+  }
+  const normalized = value.toLowerCase();
+  const translationKey = `shops.types.${normalized}`;
+  if (isTranslationKey(translationKey)) {
+    return t(translationKey);
+  }
+  return value;
+};
+
+const buildInitials = (name: string) => {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return "?";
+  }
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase();
+  }
+  return `${parts[0].charAt(0)}${parts[parts.length - 1].charAt(0)}`.toUpperCase();
+};
+
+export default function ShopsView({ shops, errorMessage, returnTo, shouldOpenModal }: ShopsViewProps) {
+  const t = createTranslator();
+  const { navigate, showSuccess } = useAppShell();
+
+  const [records, setRecords] = useState<ShopRecord[]>(() => (Array.isArray(shops) ? [...shops] : []));
+  const [searchTerm, setSearchTerm] = useState("");
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [isAddModalOpen, setAddModalOpen] = useState<boolean>(Boolean(shouldOpenModal));
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (shouldOpenModal) {
+      setAddModalOpen(true);
+    }
+  }, [shouldOpenModal]);
+
+  useEffect(() => {
+    setRecords((prev) => {
+      const existing = new Map(prev.map((shop) => [shop.id, shop] as const));
+      shops.forEach((shop) => {
+        existing.set(shop.id, { ...existing.get(shop.id), ...shop });
+      });
+      return Array.from(existing.values());
+    });
+  }, [shops]);
+
+  useEffect(() => {
+    if (!activeId && records.length > 0) {
+      setActiveId(records[0].id);
+      return;
+    }
+    if (activeId && !records.some((record) => record.id === activeId)) {
+      setActiveId(records.length > 0 ? records[0].id : null);
+    }
+  }, [activeId, records]);
+
+  const typeOptions = useMemo(() => {
+    const uniqueTypes = new Set<string>();
+    records.forEach((record) => {
+      if (record.type) {
+        uniqueTypes.add(record.type);
+      }
+    });
+    const sorted = Array.from(uniqueTypes).sort((a, b) => a.localeCompare(b));
+    return [
+      { value: "all" as TypeFilter, label: t("shops.filters.allTypes") },
+      ...sorted.map((value) => ({
+        value,
+        label: getTypeLabel(value, t),
+      })),
+    ];
+  }, [records, t]);
+
+  const filteredRecords = useMemo(() => {
+    const normalizedSearch = normalize(searchTerm);
+    return records.filter((record) => {
+      if (typeFilter !== "all") {
+        const typeValue = record.type ? record.type.toString() : "";
+        if (typeValue !== typeFilter) {
+          return false;
+        }
+      }
+      if (!normalizedSearch) {
+        return true;
+      }
+      const haystack = `${record.name ?? ""} ${record.notes ?? ""} ${record.type ?? ""}`;
+      return normalize(haystack).includes(normalizedSearch);
+    });
+  }, [records, searchTerm, typeFilter]);
+
+  useEffect(() => {
+    if (!filteredRecords.length) {
+      setActiveId(null);
+      return;
+    }
+    if (!activeId || !filteredRecords.some((record) => record.id === activeId)) {
+      setActiveId(filteredRecords[0].id);
+    }
+  }, [activeId, filteredRecords]);
+
+  const activeRecord = useMemo(() => {
+    if (!activeId) {
+      return null;
+    }
+    return filteredRecords.find((record) => record.id === activeId) ?? null;
+  }, [activeId, filteredRecords]);
+
+  const handleSearchClear = useCallback(() => {
+    setSearchTerm("");
+    searchInputRef.current?.focus();
+  }, []);
+
+  const handleOpenModal = useCallback(() => {
+    setAddModalOpen(true);
+  }, []);
+
+  const handleCloseModal = useCallback(() => {
+    setAddModalOpen(false);
+  }, []);
+
+  const handleCreateShop = useCallback((values: { name: string; type?: string; notes?: string | null }) => {
+    const id =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `shop-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+    const newRecord: ShopRecord = {
+      id,
+      name: values.name,
+      type: values.type ? values.type.trim().toLowerCase() : null,
+      image_url: null,
+      notes: values.notes ?? null,
+      created_at: new Date().toISOString(),
+    };
+
+    setRecords((prev) => [newRecord, ...prev]);
+    setActiveId(id);
+    setAddModalOpen(false);
+    showSuccess(t("shops.actions.addNew"));
+  }, [showSuccess, t]);
+
+  const handleNavigateToTransactions = useCallback(() => {
+    const destination = returnTo && returnTo.startsWith("/") ? returnTo : "/transactions";
+    navigate(destination);
+    setAddModalOpen(false);
+  }, [navigate, returnTo]);
+
+  return (
+    <div className="flex h-full flex-col gap-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-gray-900">{t("shops.title")}</h2>
+          <p className="text-sm text-gray-600">{t("shops.description")}</p>
+          <p className="text-xs text-gray-500">{t("shops.summary.count", { count: filteredRecords.length })}</p>
+          {errorMessage ? <p className="text-xs text-red-600">{errorMessage}</p> : null}
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <label className="flex flex-col text-xs font-semibold uppercase tracking-wide text-gray-600">
+            <span>{t("shops.filters.typeLabel")}</span>
+            <select
+              value={typeFilter}
+              onChange={(event) => setTypeFilter(event.target.value)}
+              className="mt-1 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+            >
+              {typeOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={handleOpenModal}
+            className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700"
+          >
+            {t("shops.actions.addNew")}
+          </button>
+        </div>
+      </div>
+
+      <div className="grid flex-1 gap-6 lg:grid-cols-[minmax(0,360px)_minmax(0,1fr)]">
+        <div className="flex flex-col gap-4">
+          <div className="relative">
+            <input
+              ref={searchInputRef}
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder={t("shops.filters.searchPlaceholder")}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+            />
+            {searchTerm ? (
+              <button
+                type="button"
+                onClick={handleSearchClear}
+                className="absolute right-1 top-1 inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-gray-500 transition hover:border-gray-200 hover:bg-gray-50"
+                aria-label={t("common.clear")}
+              >
+                <ClearIcon />
+              </button>
+            ) : null}
+          </div>
+
+          <ul className="divide-y divide-gray-200 overflow-hidden rounded-lg border border-gray-200 bg-white">
+            {filteredRecords.map((shop) => {
+              const isActive = activeId === shop.id;
+              const typeLabel = getTypeLabel(shop.type ?? null, t);
+              return (
+                <li key={shop.id}>
+                  <button
+                    type="button"
+                    onClick={() => setActiveId(shop.id)}
+                    className={`flex w-full items-center gap-3 px-4 py-3 text-left transition ${
+                      isActive ? "bg-indigo-50" : "hover:bg-gray-50"
+                    }`}
+                  >
+                    {shop.image_url ? (
+                      <RemoteImage
+                        src={shop.image_url}
+                        alt={shop.name}
+                        className="h-10 w-10 flex-shrink-0 rounded-lg object-cover"
+                      />
+                    ) : (
+                      <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-indigo-100 text-sm font-semibold text-indigo-700">
+                        {buildInitials(shop.name)}
+                      </span>
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-gray-900">{shop.name}</p>
+                      <p className="truncate text-xs text-gray-500">{typeLabel}</p>
+                    </div>
+                    <Tooltip label={formatCreatedAt(shop.created_at ?? null)}>
+                      <span className="text-xs text-gray-500">{formatCreatedAt(shop.created_at ?? null)}</span>
+                    </Tooltip>
+                  </button>
+                </li>
+              );
+            })}
+            {filteredRecords.length === 0 ? (
+              <li className="p-6 text-center text-sm text-gray-500">{t("shops.empty")}</li>
+            ) : null}
+          </ul>
+        </div>
+
+        <div className="flex min-h-[240px] items-center justify-center rounded-lg border border-dashed border-gray-300 bg-white p-6">
+          {activeRecord ? (
+            <div className="flex w-full flex-col gap-4">
+              <div className="flex items-center gap-4">
+                {activeRecord.image_url ? (
+                  <RemoteImage
+                    src={activeRecord.image_url}
+                    alt={activeRecord.name}
+                    className="h-14 w-14 flex-shrink-0 rounded-xl object-cover"
+                  />
+                ) : (
+                  <span className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-xl bg-indigo-100 text-base font-semibold text-indigo-700">
+                    {buildInitials(activeRecord.name)}
+                  </span>
+                )}
+                <div className="min-w-0">
+                  <h3 className="truncate text-lg font-semibold text-gray-900">{activeRecord.name}</h3>
+                  <p className="truncate text-sm text-gray-500">{getTypeLabel(activeRecord.type ?? null, t)}</p>
+                </div>
+              </div>
+
+              <dl className="grid grid-cols-1 gap-4 text-sm text-gray-600 sm:grid-cols-2">
+                <div className="space-y-1">
+                  <dt className="font-medium text-gray-500">{t("shops.fields.type")}</dt>
+                  <dd>{getTypeLabel(activeRecord.type ?? null, t)}</dd>
+                </div>
+                <div className="space-y-1">
+                  <dt className="font-medium text-gray-500">{t("shops.fields.created")}</dt>
+                  <dd>{formatCreatedAt(activeRecord.created_at ?? null)}</dd>
+                </div>
+                {activeRecord.notes ? (
+                  <div className="sm:col-span-2">
+                    <dt className="font-medium text-gray-500">{t("common.notes")}</dt>
+                    <dd className="whitespace-pre-wrap text-gray-700">{activeRecord.notes}</dd>
+                  </div>
+                ) : null}
+              </dl>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500">{t("shops.empty")}</p>
+          )}
+        </div>
+      </div>
+
+      <AddShopModal
+        open={isAddModalOpen}
+        onClose={handleCloseModal}
+        onCreate={handleCreateShop}
+        onNavigateToTransactions={handleNavigateToTransactions}
+      />
+    </div>
+  );
+}

--- a/src/app/transactions/TransactionsView.tsx
+++ b/src/app/transactions/TransactionsView.tsx
@@ -745,13 +745,17 @@ export default function TransactionsView({
     return formatDateTag(date);
   }, []);
 
-  const tagOptions = useMemo(
-    () => [
+  const tagOptions = useMemo(() => {
+    const base: { value: string; label: string; disabled?: boolean }[] = [
       { value: "all", label: t("transactions.filters.allTags") },
-      ...sortedTagValues.map((tag) => ({ value: tag, label: tag })),
-    ],
-    [sortedTagValues, t]
-  );
+    ];
+
+    sortedTagValues.forEach((tag) => {
+      base.push({ value: tag, label: tag });
+    });
+
+    return base;
+  }, [sortedTagValues, t]);
 
   const debtCycleOptions = useMemo(() => {
     const hasCurrent = currentDebtTag ? debtTagValues.includes(currentDebtTag) : false;

--- a/src/app/transactions/add/TransactionForm.tsx
+++ b/src/app/transactions/add/TransactionForm.tsx
@@ -1,1013 +1,1169 @@
-diff --git a/src/app/transactions/add/TransactionForm.tsx b/src/app/transactions/add/TransactionForm.tsx
-index b907e4178119e7381f3f666b1d29a2abc53ed806..265d4d473f204c1402ef5758a2e24c5a030eefa9 100644
---- a/src/app/transactions/add/TransactionForm.tsx
-+++ b/src/app/transactions/add/TransactionForm.tsx
-@@ -1,39 +1,40 @@
- "use client";
- 
--import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
- import { useRouter } from "next/navigation";
- import { Account, Subcategory, Person, Shop } from "./formData";
- import { createTransaction, updateTransaction } from "../actions";
- import AmountInput from "@/components/forms/AmountInput";
- import CustomSelect from "@/components/forms/CustomSelect";
- import CashbackInput from "@/components/forms/CashbackInput";
- import { createTranslator } from "@/lib/i18n";
- import { normalizeTransactionNature, type TransactionNatureCode } from "@/lib/transactionNature";
- import { useAppShell } from "@/components/AppShellProvider";
- import ConfirmDialog from "@/components/ui/ConfirmDialog";
- import { formatDateTag } from "@/lib/dateTag";
-+import AddShopModal from "@/components/shops/AddShopModal";
- import type { TransactionListItem } from "../types";
- 
- type Tab = "expense" | "income" | "transfer" | "debt";
- type DebtMode = "collect" | "lend";
- type TransactionFormProps = {
-   accounts: Account[];
-   subcategories: Subcategory[];
-   people: Person[];
-   shops: Shop[];
-   returnTo: string;
-   createdSubcategoryId?: string;
-   initialTab?: Tab;
-   initialTransaction?: TransactionListItem;
-   mode?: "create" | "edit";
-   onClose?: () => void;
-   layout?: "page" | "modal";
- };
- type CashbackInfo = { percent: number; amount: number; source: CashbackSource };
- type CashbackSource = "percent" | "amount" | null;
- 
- const formatAmountForInput = (value: number | null | undefined) => {
-   if (value == null || Number.isNaN(value)) {
-     return "";
-   }
-   const rounded = Math.round(value);
-diff --git a/src/app/transactions/add/TransactionForm.tsx b/src/app/transactions/add/TransactionForm.tsx
-index b907e4178119e7381f3f666b1d29a2abc53ed806..265d4d473f204c1402ef5758a2e24c5a030eefa9 100644
---- a/src/app/transactions/add/TransactionForm.tsx
-+++ b/src/app/transactions/add/TransactionForm.tsx
-@@ -102,50 +103,53 @@ const extractCashbackInfoFromTransaction = (transaction: TransactionListItem): {
- 
-   return {
-     info: {
-       percent: percentValue,
-       amount: amountValue,
-       source: derivedSource,
-     },
-     show: percentValue > 0 || amountValue > 0,
-   };
- };
- 
- type PersistedState = {
-   activeTab: Tab;
-   amount: string;
-   fromAccountId: string;
-   toAccountId: string;
-   subcategoryId: string;
-   personId: string;
-   notes: string;
-   date: string;
-   cashbackPercent: number;
-   cashbackAmount: number;
-   cashbackSource: CashbackSource;
-   debtMode: DebtMode;
-   shopId: string;
-+  debtTag: string;
-+  debtCycleTag: string;
-+  useLastMonthTag: boolean;
- };
- 
- const STORAGE_KEY = "transactions:add-form-state";
- const PRESERVE_KEY = `${STORAGE_KEY}:preserve`;
- 
- const tabColors: Record<Tab, string> = {
-   expense: "bg-red-500",
-   income: "bg-green-500",
-   transfer: "bg-blue-500",
-   debt: "bg-yellow-500",
- };
- 
- const debtModePalette: Record<DebtMode, { active: string; inactive: string }> = {
-   lend: {
-     active: "bg-rose-500 text-white shadow",
-     inactive: "border border-rose-300 bg-white text-rose-700 hover:bg-rose-50",
-   },
-   collect: {
-     active: "bg-emerald-500 text-white shadow",
-     inactive: "border border-emerald-300 bg-white text-emerald-700 hover:bg-emerald-50",
-   },
- };
- 
- const TabButton = ({
-   title,
-diff --git a/src/app/transactions/add/TransactionForm.tsx b/src/app/transactions/add/TransactionForm.tsx
-index b907e4178119e7381f3f666b1d29a2abc53ed806..265d4d473f204c1402ef5758a2e24c5a030eefa9 100644
---- a/src/app/transactions/add/TransactionForm.tsx
-+++ b/src/app/transactions/add/TransactionForm.tsx
-@@ -179,140 +183,227 @@ export default function TransactionForm({
-   initialTab,
-   initialTransaction,
-   mode = "create",
-   onClose,
-   layout = "page",
- }: TransactionFormProps) {
-   const t = createTranslator();
-   const router = useRouter();
-   const { showSuccess, navigate } = useAppShell();
-   const isEditMode = mode === "edit";
-   const editingTransaction = isEditMode && initialTransaction ? initialTransaction : null;
- 
-   const persistedStateRef = useRef<PersistedState | null>(null);
-   if (!isEditMode && persistedStateRef.current === null && typeof window !== "undefined") {
-     try {
-       const shouldPreserve = sessionStorage.getItem(PRESERVE_KEY) === "1";
-       const raw = sessionStorage.getItem(STORAGE_KEY);
-       if (!shouldPreserve) {
-         sessionStorage.removeItem(STORAGE_KEY);
-       } else {
-         sessionStorage.removeItem(PRESERVE_KEY);
-       }
-       if (raw && shouldPreserve) {
-         const parsed = JSON.parse(raw) as Partial<PersistedState>;
-         const today = new Date().toISOString().split("T")[0];
-+        const fallbackTag = formatDateTag(new Date()) ?? "";
-         persistedStateRef.current = {
-           activeTab: parsed.activeTab ?? "expense",
-           amount: parsed.amount ?? "",
-           fromAccountId: parsed.fromAccountId ?? "",
-           toAccountId: parsed.toAccountId ?? "",
-           subcategoryId: parsed.subcategoryId ?? "",
-           personId: parsed.personId ?? "",
-           notes: parsed.notes ?? "",
-           date: parsed.date ?? today,
-           cashbackPercent: parsed.cashbackPercent ?? 0,
-           cashbackAmount: parsed.cashbackAmount ?? 0,
-           cashbackSource:
-             parsed.cashbackSource === "percent" || parsed.cashbackSource === "amount"
-               ? parsed.cashbackSource
-               : null,
-           debtMode: parsed.debtMode === "collect" ? "collect" : "lend",
-           shopId: parsed.shopId ?? "",
-+          debtTag: typeof parsed.debtTag === "string" ? parsed.debtTag : fallbackTag,
-+          debtCycleTag: typeof parsed.debtCycleTag === "string" ? parsed.debtCycleTag : fallbackTag,
-+          useLastMonthTag: Boolean(parsed.useLastMonthTag),
-         };
-       }
-     } catch {
-       persistedStateRef.current = null;
-     }
-   }
- 
-   const persistedState = isEditMode ? null : persistedStateRef.current;
-   const defaultTabValue: Tab = editingTransaction
-     ? determineTabFromTransactionRecord(editingTransaction)
-     : persistedState?.activeTab ?? initialTab ?? "expense";
-   const defaultAmount = editingTransaction
-     ? formatAmountForInput(editingTransaction.amount)
-     : persistedState?.amount ?? "";
-   const defaultFromAccount = editingTransaction?.fromAccountId ?? persistedState?.fromAccountId ?? "";
-   const defaultToAccount = editingTransaction?.toAccountId ?? persistedState?.toAccountId ?? "";
-   const defaultSubcategory = editingTransaction?.subcategoryId ?? persistedState?.subcategoryId ?? "";
-   const defaultPerson = editingTransaction?.personId ?? persistedState?.personId ?? "";
-   const defaultNotes = editingTransaction?.notes ?? persistedState?.notes ?? "";
-   const defaultDate = editingTransaction ? toDateInputValue(editingTransaction.date) : persistedState?.date ?? new Date().toISOString().split("T")[0];
-   const { info: editingCashbackInfo, show: editingShowCashback } = editingTransaction
-     ? extractCashbackInfoFromTransaction(editingTransaction)
-     : { info: { percent: 0, amount: 0, source: null }, show: false };
-   const defaultCashbackPercent = editingTransaction ? editingCashbackInfo.percent : persistedState?.cashbackPercent ?? 0;
-   const defaultCashbackAmount = editingTransaction ? editingCashbackInfo.amount : persistedState?.cashbackAmount ?? 0;
-   const defaultCashbackSource: CashbackSource = editingTransaction
-     ? editingCashbackInfo.source
-     : persistedState?.cashbackSource ?? null;
-   const defaultDebtMode: DebtMode = editingTransaction && defaultTabValue === "debt"
-     ? inferDebtModeFromTransaction(editingTransaction)
-     : persistedState?.debtMode ?? "lend";
-   const defaultShopId = editingTransaction?.shopId ?? persistedState?.shopId ?? "";
-+  const fallbackDebtTag = formatDateTag(editingTransaction?.date ?? new Date()) ?? "";
-+  const defaultDebtTag = editingTransaction?.debtTag ?? persistedState?.debtTag ?? fallbackDebtTag;
-+  const defaultDebtCycleTag = editingTransaction?.debtCycleTag ?? persistedState?.debtCycleTag ?? fallbackDebtTag;
-+  const defaultUseLastMonthTag = persistedState?.useLastMonthTag ?? false;
- 
-   const [activeTab, setActiveTab] = useState<Tab>(defaultTabValue);
-   const [amount, setAmount] = useState(defaultAmount);
-   const [fromAccountId, setFromAccountId] = useState(defaultFromAccount);
-   const [toAccountId, setToAccountId] = useState(defaultToAccount);
-   const [subcategoryId, setSubcategoryId] = useState(defaultSubcategory);
-   const [personId, setPersonId] = useState(defaultPerson);
-   const [notes, setNotes] = useState(defaultNotes);
-   const [isSubmitting, setIsSubmitting] = useState(false);
-   const [date, setDate] = useState(defaultDate);
-   const [debtMode, setDebtMode] = useState<DebtMode>(defaultDebtMode);
-   const [shopId, setShopId] = useState(defaultShopId);
-   const [showLeaveDialog, setShowLeaveDialog] = useState(false);
-+  const [debtTagValue, setDebtTagValue] = useState(defaultDebtTag);
-+  const [debtCycleTagValue, setDebtCycleTagValue] = useState(defaultDebtCycleTag);
-+  const [useLastMonthTag, setUseLastMonthTag] = useState(defaultUseLastMonthTag);
-+  const [shopRecords, setShopRecords] = useState<Shop[]>(() => shops);
-+  const [isShopModalOpen, setShopModalOpen] = useState(false);
- 
-   const [showCashback, setShowCashback] = useState(() => (isEditMode ? editingShowCashback : false));
-   const [selectedAccount, setSelectedAccount] = useState<Account | null>(() => {
-     if (defaultFromAccount) {
-       return accounts.find((account) => account.id === defaultFromAccount) ?? null;
-     }
-     return null;
-   });
-   const [cashbackInfo, setCashbackInfo] = useState<CashbackInfo>({
-     percent: defaultCashbackPercent,
-     amount: defaultCashbackAmount,
-     source: defaultCashbackSource,
-   });
- 
-+  const debtTagInputId = useId();
-+  const debtCycleInputId = useId();
-+  const debtTagListId = useId();
-+
-+  const recentDebtTags = useMemo(() => {
-+    const tags = new Set<string>();
-+    const addTag = (value?: string | null) => {
-+      if (!value) {
-+        return;
-+      }
-+      const trimmed = value.trim();
-+      if (trimmed) {
-+        tags.add(trimmed);
-+      }
-+    };
-+    for (let offset = 0; offset < 6; offset += 1) {
-+      const reference = new Date();
-+      reference.setMonth(reference.getMonth() - offset, 1);
-+      addTag(formatDateTag(reference));
-+    }
-+    addTag(debtTagValue);
-+    addTag(debtCycleTagValue);
-+    return Array.from(tags);
-+  }, [debtCycleTagValue, debtTagValue]);
-+
-+  const handleToggleLastMonth = useCallback(
-+    (checked: boolean) => {
-+      setUseLastMonthTag(checked);
-+      if (checked) {
-+        const previous = new Date();
-+        previous.setMonth(previous.getMonth() - 1, 1);
-+        const tag = formatDateTag(previous) ?? "";
-+        setDebtTagValue(tag);
-+      } else if (!debtTagValue.trim()) {
-+        const current = formatDateTag(new Date()) ?? "";
-+        setDebtTagValue(current);
-+      }
-+    },
-+    [debtTagValue]
-+  );
-+
-+  useEffect(() => {
-+    setShopRecords((prev) => {
-+      const existingIds = new Set(prev.map((shop) => shop.id));
-+      const merged = [...prev];
-+      shops.forEach((shop) => {
-+        if (!existingIds.has(shop.id)) {
-+          merged.push(shop);
-+        }
-+      });
-+      return merged;
-+    });
-+  }, [shops]);
-+
-+  useEffect(() => {
-+    if (debtMode === "collect" && useLastMonthTag) {
-+      setUseLastMonthTag(false);
-+    }
-+  }, [debtMode, useLastMonthTag]);
-+
-+  useEffect(() => {
-+    if (debtMode === "collect" && !debtCycleTagValue.trim()) {
-+      const currentTag = formatDateTag(new Date()) ?? "";
-+      setDebtCycleTagValue(currentTag);
-+    }
-+    if (debtMode === "lend" && !debtTagValue.trim()) {
-+      const currentTag = formatDateTag(new Date()) ?? "";
-+      setDebtTagValue(currentTag);
-+    }
-+  }, [debtMode, debtCycleTagValue, debtTagValue]);
-+
-   const initialSnapshotRef = useRef<PersistedState>({
-     activeTab: defaultTabValue,
-     amount: defaultAmount,
-     fromAccountId: defaultFromAccount,
-     toAccountId: defaultToAccount,
-     subcategoryId: defaultSubcategory,
-     personId: defaultPerson,
-     notes: defaultNotes,
-     date: defaultDate,
-     cashbackPercent: defaultCashbackPercent,
-     cashbackAmount: defaultCashbackAmount,
-     cashbackSource: defaultCashbackSource,
-     debtMode: defaultDebtMode,
-     shopId: defaultShopId,
-+    debtTag: defaultDebtTag,
-+    debtCycleTag: defaultDebtCycleTag,
-+    useLastMonthTag: defaultUseLastMonthTag,
-   });
- 
-   // Determine whether to show cashback input based on the selected expense account
-   useEffect(() => {
-     const account = accounts.find((a) => a.id === fromAccountId) ?? null;
-     setSelectedAccount(account);
-     const shouldEnableCashback = Boolean(account?.is_cashback_eligible) ||
-       (isEditMode && editingTransaction && editingTransaction.fromAccountId === account?.id && editingShowCashback);
- 
-     if (shouldEnableCashback) {
-       setShowCashback(true);
-     } else {
-       setShowCashback(false);
-       setCashbackInfo({ percent: 0, amount: 0, source: null });
-     }
-   }, [accounts, fromAccountId, editingShowCashback, editingTransaction, isEditMode]);
- 
-   const getTransactionNature = useCallback((sub: Subcategory): TransactionNatureCode | null => {
-     const direct = normalizeTransactionNature(sub.transaction_nature ?? null);
-     if (direct) {
-       return direct;
-     }
-     if (!sub.categories) return null;
-     if (Array.isArray(sub.categories)) {
-       return normalizeTransactionNature(sub.categories[0]?.transaction_nature ?? null);
-diff --git a/src/app/transactions/add/TransactionForm.tsx b/src/app/transactions/add/TransactionForm.tsx
-index b907e4178119e7381f3f666b1d29a2abc53ed806..265d4d473f204c1402ef5758a2e24c5a030eefa9 100644
---- a/src/app/transactions/add/TransactionForm.tsx
-+++ b/src/app/transactions/add/TransactionForm.tsx
-@@ -341,69 +432,76 @@ export default function TransactionForm({
-     setSubcategoryId(createdSubcategoryId);
-     const mappedTab = mapNatureToTab(getTransactionNature(newlyCreated));
-     if (mappedTab && mappedTab !== activeTab) {
-       setActiveTab(mappedTab);
-     }
-   }, [createdSubcategoryId, subcategories, mapNatureToTab, getTransactionNature, activeTab]);
- 
-   const mapToOptions = useCallback(
-     (item: {
-       id: string;
-       name: string;
-       image_url?: string | null;
-       type?: string | null;
-       is_group?: boolean | null;
-     }) => ({
-       id: item.id,
-       name: item.name,
-       imageUrl: item.image_url || undefined,
-       type:
-         item.type ||
-         (typeof item.is_group === "boolean" ? (item.is_group ? "Group" : "Individual") : undefined),
-     }),
-     []
-   );
- 
-+  const generateShopId = useCallback(() => {
-+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-+      return crypto.randomUUID();
-+    }
-+    return `shop-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-+  }, []);
-+
-   const expenseCategories = useMemo(
-     () => subcategories.filter((s) => getTransactionNature(s) === "EX").map(mapToOptions),
-     [subcategories, getTransactionNature, mapToOptions]
-   );
-   const incomeCategories = useMemo(
-     () => subcategories.filter((s) => getTransactionNature(s) === "IN").map(mapToOptions),
-     [subcategories, getTransactionNature, mapToOptions]
-   );
-   const transferCategories = useMemo(
-     () => subcategories.filter((s) => getTransactionNature(s) === "TF").map(mapToOptions),
-     [subcategories, getTransactionNature, mapToOptions]
-   );
-   const accountsWithOptions = useMemo(() => accounts.map(mapToOptions), [accounts, mapToOptions]);
-   const bankAccountOptions = useMemo(
-     () => accounts.filter((account) => account.type?.toLowerCase() === "bank").map(mapToOptions),
-     [accounts, mapToOptions]
-   );
-   const peopleWithOptions = useMemo(() => people.map(mapToOptions), [people, mapToOptions]);
--  const shopOptions = useMemo(() => shops.map(mapToOptions), [mapToOptions, shops]);
-+  const shopOptions = useMemo(() => shopRecords.map(mapToOptions), [mapToOptions, shopRecords]);
- 
-   const selectedSubcategory = useMemo(() => {
-     if (!subcategoryId) {
-       return null;
-     }
-     return subcategories.find((item) => item.id === subcategoryId) ?? null;
-   }, [subcategoryId, subcategories]);
- 
-   const isShopCategory = selectedSubcategory?.is_shop ?? false;
- 
-   const shouldShowShopSection = useMemo(() => {
-     if (activeTab === "debt") {
-       return true;
-     }
-     if (activeTab === "expense" || activeTab === "income") {
-       return Boolean(isShopCategory || shopId);
-     }
-     if (activeTab === "transfer") {
-       return Boolean(shopId);
-     }
-     return false;
-   }, [activeTab, isShopCategory, shopId]);
- 
-   useEffect(() => {
-     if (!shouldShowShopSection && shopId) {
-diff --git a/src/app/transactions/add/TransactionForm.tsx b/src/app/transactions/add/TransactionForm.tsx
-index b907e4178119e7381f3f666b1d29a2abc53ed806..265d4d473f204c1402ef5758a2e24c5a030eefa9 100644
---- a/src/app/transactions/add/TransactionForm.tsx
-+++ b/src/app/transactions/add/TransactionForm.tsx
-@@ -421,55 +519,72 @@ export default function TransactionForm({
-       setFromAccountId("");
-       if (bankAccountOptions.length > 0 && !bankAccountOptions.some((option) => option.id === toAccountId)) {
-         setToAccountId(bankAccountOptions[0].id);
-       }
-     }
-   }, [activeTab, bankAccountOptions, debtMode, toAccountId]);
- 
-   const addCategoryLabel = useMemo(() => {
-     switch (activeTab) {
-       case "income":
-         return t("transactionForm.addCategory.income");
-       case "transfer":
-         return t("transactionForm.addCategory.transfer");
-       case "debt":
-         return t("transactionForm.addCategory.debt");
-       default:
-         return t("transactionForm.addCategory.expense");
-     }
-   }, [activeTab, t]);
- 
-   const handleAddAccount = useCallback(() => {
-     alert(t("transactionForm.addAccountPlaceholder"));
-   }, [t]);
- 
-   const handleAddShop = useCallback(() => {
--    if (typeof window !== "undefined") {
--      sessionStorage.setItem(PRESERVE_KEY, "1");
--    }
--    router.push("/shops");
--  }, [router]);
-+    setShopModalOpen(true);
-+  }, []);
-+
-+  const handleCreateShopRecord = useCallback(
-+    (values: { name: string; type?: string; notes?: string | null }) => {
-+      const id = generateShopId();
-+      const record: Shop = {
-+        id,
-+        name: values.name,
-+        image_url: null,
-+        type: values.type ? values.type.toLowerCase() : null,
-+        created_at: new Date().toISOString(),
-+      };
-+      setShopRecords((prev) => [record, ...prev]);
-+      setShopId(id);
-+      setShopModalOpen(false);
-+      showSuccess(t("transactionForm.shop.createSuccess"));
-+    },
-+    [generateShopId, showSuccess, t]
-+  );
-+
-+  const handleCloseShopModal = useCallback(() => setShopModalOpen(false), []);
- 
-   const returnPath = useMemo(() => {
-     const params = new URLSearchParams();
-     params.set("tab", activeTab);
-     const query = params.toString();
-     return query ? `/transactions/add?${query}` : "/transactions/add";
-   }, [activeTab]);
- 
-   const handleAddCategory = useCallback(() => {
-     const natureMap: Record<Tab, string> = {
-       expense: "EX",
-       income: "IN",
-       transfer: "TF",
-       debt: "DE",
-     };
-     if (typeof window !== "undefined") {
-       sessionStorage.setItem(PRESERVE_KEY, "1");
-     }
-     const params = new URLSearchParams({
-       defaultNature: natureMap[activeTab],
-     });
-     params.set("returnTo", encodeURIComponent(returnPath));
-     router.push(`/categories/add?${params.toString()}`);
-   }, [activeTab, returnPath, router]);
- 
-diff --git a/src/app/transactions/add/TransactionForm.tsx b/src/app/transactions/add/TransactionForm.tsx
-index b907e4178119e7381f3f666b1d29a2abc53ed806..265d4d473f204c1402ef5758a2e24c5a030eefa9 100644
---- a/src/app/transactions/add/TransactionForm.tsx
-+++ b/src/app/transactions/add/TransactionForm.tsx
-@@ -477,211 +592,257 @@ export default function TransactionForm({
-     if (typeof window !== "undefined") {
-       sessionStorage.removeItem(STORAGE_KEY);
-       sessionStorage.removeItem(PRESERVE_KEY);
-     }
-     if (onClose) {
-       onClose();
-     }
-     navigate(returnTo);
-   }, [navigate, onClose, returnTo]);
- 
-   const isDirty = useMemo(() => {
-     const snapshot = initialSnapshotRef.current;
-     return (
-       snapshot.activeTab !== activeTab ||
-       snapshot.amount !== amount ||
-       snapshot.fromAccountId !== fromAccountId ||
-       snapshot.toAccountId !== toAccountId ||
-       snapshot.subcategoryId !== subcategoryId ||
-       snapshot.personId !== personId ||
-       snapshot.notes !== notes ||
-       snapshot.date !== date ||
-       snapshot.cashbackPercent !== cashbackInfo.percent ||
-       snapshot.cashbackAmount !== cashbackInfo.amount ||
-       snapshot.cashbackSource !== cashbackInfo.source ||
-       snapshot.debtMode !== debtMode ||
--      snapshot.shopId !== shopId
-+      snapshot.shopId !== shopId ||
-+      snapshot.debtTag !== debtTagValue ||
-+      snapshot.debtCycleTag !== debtCycleTagValue ||
-+      snapshot.useLastMonthTag !== useLastMonthTag
-     );
--  }, [activeTab, amount, fromAccountId, toAccountId, subcategoryId, personId, notes, date, cashbackInfo, debtMode, shopId]);
-+  }, [
-+    activeTab,
-+    amount,
-+    fromAccountId,
-+    toAccountId,
-+    subcategoryId,
-+    personId,
-+    notes,
-+    date,
-+    cashbackInfo,
-+    debtMode,
-+    shopId,
-+    debtTagValue,
-+    debtCycleTagValue,
-+    useLastMonthTag,
-+  ]);
- 
-   const handleBack = useCallback(() => {
-     if (isDirty) {
-       setShowLeaveDialog(true);
-       return;
-     }
-     completeNavigation();
-   }, [completeNavigation, isDirty]);
- 
-   const handleConfirmLeave = useCallback(() => {
-     setShowLeaveDialog(false);
-     completeNavigation();
-   }, [completeNavigation]);
- 
-   const handleCancelLeave = useCallback(() => {
-     setShowLeaveDialog(false);
-   }, []);
- 
-   useEffect(() => {
-     if (typeof window === "undefined" || isEditMode) {
-       return;
-     }
-     const payload: PersistedState = {
-       activeTab,
-       amount,
-       fromAccountId,
-       toAccountId,
-       subcategoryId,
-       personId,
-       notes,
-       date,
-       cashbackPercent: cashbackInfo.percent,
-       cashbackAmount: cashbackInfo.amount,
-       cashbackSource: cashbackInfo.source,
-       debtMode,
-       shopId,
-+      debtTag: debtTagValue,
-+      debtCycleTag: debtCycleTagValue,
-+      useLastMonthTag,
-     };
-     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
-     persistedStateRef.current = payload;
--  }, [activeTab, amount, cashbackInfo, debtMode, fromAccountId, isEditMode, notes, personId, shopId, subcategoryId, toAccountId, date]);
-+  }, [
-+    activeTab,
-+    amount,
-+    cashbackInfo,
-+    debtMode,
-+    fromAccountId,
-+    isEditMode,
-+    notes,
-+    personId,
-+    shopId,
-+    subcategoryId,
-+    toAccountId,
-+    date,
-+    debtTagValue,
-+    debtCycleTagValue,
-+    useLastMonthTag,
-+  ]);
- 
-   const handleSubmit = async (e: React.FormEvent) => {
-     e.preventDefault();
-     if (activeTab === "transfer" && fromAccountId && fromAccountId === toAccountId) {
-       alert(t("transactionForm.errors.sameTransferAccount"));
-       return;
-     }
-     setIsSubmitting(true);
- 
-     const sanitizedCashback = showCashback
-       ? {
-           percent: Number.isFinite(cashbackInfo.percent) ? Number(cashbackInfo.percent) : 0,
-           amount: Number.isFinite(cashbackInfo.amount) ? Number(cashbackInfo.amount) : 0,
-           source: cashbackInfo.source,
-         }
-       : null;
- 
-     const preparedFromAccountId = activeTab === "debt" && debtMode === "collect" ? "" : fromAccountId;
-     const preparedToAccountId = activeTab === "debt" && debtMode === "lend" ? "" : toAccountId;
- 
-     const normalizedNotes = notes?.trim() ? notes.trim() : null;
-     const sanitizedPayload = {
-       activeTab,
-       amount: parseFloat(amount.replace(/,/g, "")),
-       notes: normalizedNotes,
-       fromAccountId: preparedFromAccountId?.trim() ? preparedFromAccountId.trim() : undefined,
-       toAccountId: preparedToAccountId?.trim() ? preparedToAccountId.trim() : undefined,
-       subcategoryId: subcategoryId?.trim() ? subcategoryId.trim() : undefined,
-       personId: personId?.trim() ? personId.trim() : undefined,
-       date,
-       cashback: sanitizedCashback,
-       debtMode,
-       shopId: shopId?.trim() ? shopId.trim() : undefined,
-+      debtTag:
-+        activeTab === "debt" && debtMode !== "collect"
-+          ? debtTagValue.trim() || undefined
-+          : undefined,
-+      debtCycleTag:
-+        activeTab === "debt" && debtMode === "collect"
-+          ? debtCycleTagValue.trim() || undefined
-+          : undefined,
-     };
- 
-     const result = isEditMode && editingTransaction
-       ? await updateTransaction({ id: editingTransaction.id, ...sanitizedPayload })
-       : await createTransaction(sanitizedPayload);
- 
-     setIsSubmitting(false);
- 
-     if (!result.success) {
-       alert(result.message);
-       return;
-     }
- 
-     if (typeof window !== "undefined") {
-       sessionStorage.removeItem(STORAGE_KEY);
-       sessionStorage.removeItem(PRESERVE_KEY);
-     }
- 
-     showSuccess(result.message);
-     navigate(returnTo);
-   };
- 
-   useEffect(() => {
-     if (isEditMode) {
-       return () => undefined;
-     }
-     return () => {
-       if (typeof window !== "undefined") {
-         const shouldPreserve = sessionStorage.getItem(PRESERVE_KEY) === "1";
-         if (!shouldPreserve) {
-           sessionStorage.removeItem(STORAGE_KEY);
-           sessionStorage.removeItem(PRESERVE_KEY);
-         }
-       }
-     };
-   }, [isEditMode]);
- 
-   const formClasses =
-     layout === "modal"
-       ? "flex h-full min-h-0 flex-col overflow-hidden"
-       : "overflow-hidden rounded-lg border border-gray-200 shadow-sm";
- 
-   const contentWrapperClasses =
-     layout === "modal"
-       ? "flex-1 min-h-0 overflow-y-auto bg-white p-6 space-y-6"
-       : "space-y-6 bg-white p-6";
-   const dateTag = useMemo(() => formatDateTag(date), [date]);
- 
-   return (
--    <form onSubmit={handleSubmit} className={formClasses}>
-+    <>
-+      <form onSubmit={handleSubmit} className={formClasses}>
-       {layout === "modal" ? (
-         <div className="flex flex-shrink-0 items-center justify-between border-b border-gray-200 bg-white px-6 py-4">
-           <button
-             type="button"
-             onClick={handleBack}
-             className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-gray-300 text-gray-600 transition hover:bg-gray-100"
-             aria-label={t("common.close")}
-           >
-             <CloseIcon />
-           </button>
-           <h2 className="text-lg font-semibold text-gray-900">{t("transactionForm.title")}</h2>
-           <span className="h-9 w-9" aria-hidden="true" />
-         </div>
-       ) : null}
-       <div className="flex flex-shrink-0 flex-col gap-3 border-b border-gray-200 bg-gray-50 px-6 py-4 md:flex-row md:items-center md:justify-between">
-         <div className="grid flex-1 grid-cols-2 gap-2 md:grid-cols-4">
-           <TabButton title={t("transactionForm.tabs.expense")} active={activeTab === "expense"} color={tabColors.expense} onClick={() => setActiveTab("expense")} />
-           <TabButton title={t("transactionForm.tabs.income")} active={activeTab === "income"} color={tabColors.income} onClick={() => setActiveTab("income")} />
-           <TabButton title={t("transactionForm.tabs.transfer")} active={activeTab === "transfer"} color={tabColors.transfer} onClick={() => setActiveTab("transfer")} />
-           <TabButton title={t("transactionForm.tabs.debt")} active={activeTab === "debt"} color={tabColors.debt} onClick={() => setActiveTab("debt")} />
-         </div>
-       </div>
- 
-       <div className={contentWrapperClasses}>
-         <div className="grid gap-6 md:grid-cols-2">
-           <AmountInput value={amount} onChange={setAmount} />
-           <div>
-             <label className="block text-sm font-medium text-gray-700">{t("common.date")}</label>
-             <input
-               type="date"
-               value={date}
-               onChange={(e) => setDate(e.target.value)}
-               className="mt-1 block w-full rounded-md border border-gray-300 px-4 py-3 text-base shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-             />
--            {dateTag ? (
-+            {activeTab !== "debt" && dateTag ? (
-               <div className="mt-2">
-                 <span className="inline-flex items-center rounded-full border border-indigo-200 bg-indigo-50 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-indigo-700">
-                   {dateTag}
-                 </span>
-               </div>
-             ) : null}
-           </div>
-         </div>
- 
-         {activeTab === "expense" && (
-           <>
-             <CustomSelect
-               label={t("transactionForm.labels.fromAccount")}
-               value={fromAccountId}
-               onChange={setFromAccountId}
-               options={accountsWithOptions}
-               required
-               onAddNew={handleAddAccount}
-               addNewLabel={t("transactionForm.addAccount")}
-             />
- 
-             {showCashback && selectedAccount && (
-               <CashbackInput
-                 transactionAmount={amount}
-                 account={selectedAccount}
-diff --git a/src/app/transactions/add/TransactionForm.tsx b/src/app/transactions/add/TransactionForm.tsx
-index b907e4178119e7381f3f666b1d29a2abc53ed806..265d4d473f204c1402ef5758a2e24c5a030eefa9 100644
---- a/src/app/transactions/add/TransactionForm.tsx
-+++ b/src/app/transactions/add/TransactionForm.tsx
-@@ -747,168 +908,228 @@ export default function TransactionForm({
-               />
-               <CustomSelect
-                 label={t("transactionForm.labels.toAccount")}
-                 value={toAccountId}
-                 onChange={setToAccountId}
-                 options={accountsWithOptions}
-                 required
-                 onAddNew={handleAddAccount}
-                 addNewLabel={t("transactionForm.addAccount")}
-               />
-             </div>
-             <p className="text-xs text-indigo-600">{t("transactionForm.hints.transferSameAccount")}</p>
-           </>
-         )}
- 
-         {activeTab === "debt" && (
-           <>
-             <CustomSelect
-               label={t("transactionForm.labels.whoOwes")}
-               value={personId}
-               onChange={setPersonId}
-               options={peopleWithOptions}
-               required
-             />
- 
--            <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-4 shadow-sm">
--              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
--                <span className="text-sm font-semibold uppercase tracking-wide text-amber-800">
--                  {t("transactionForm.debtModes.label")}
--                </span>
-+            <div className="rounded-lg border border-amber-200 bg-amber-50 shadow-sm">
-+              <div className="flex flex-col gap-3 border-b border-amber-100 bg-amber-100/60 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-+                <div>
-+                  <p className="text-sm font-semibold uppercase tracking-wide text-amber-900">
-+                    {t("transactionForm.debt.directionTitle")}
-+                  </p>
-+                  <p className="text-xs text-amber-800">{t("transactionForm.debt.directionHelper")}</p>
-+                </div>
-                 <div className="flex flex-wrap gap-2 sm:gap-3">
-                   {(["lend", "collect"] as DebtMode[]).map((mode) => (
-                     <button
-                       key={mode}
-                       type="button"
-                       onClick={() => setDebtMode(mode)}
-                       className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
-                         debtMode === mode
-                           ? debtModePalette[mode].active
-                           : debtModePalette[mode].inactive
-                       }`}
-                       aria-pressed={debtMode === mode}
-                     >
-                       {t(`transactionForm.debtModes.${mode}` as const)}
-                     </button>
-                   ))}
-                 </div>
-               </div>
-+              <div className="grid gap-4 px-4 py-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
-+                <div className="space-y-2">
-+                  <label
-+                    className={`text-sm font-medium ${
-+                      debtMode === "collect" ? "text-emerald-800" : "text-amber-800"
-+                    }`}
-+                    htmlFor={debtMode === "collect" ? debtCycleInputId : debtTagInputId}
-+                  >
-+                    {debtMode === "collect"
-+                      ? t("transactionForm.debt.cycleLabel")
-+                      : t("transactionForm.debt.tagLabel")}
-+                  </label>
-+                  <input
-+                    id={debtMode === "collect" ? debtCycleInputId : debtTagInputId}
-+                    list={debtTagListId}
-+                    value={debtMode === "collect" ? debtCycleTagValue : debtTagValue}
-+                    onChange={(event) =>
-+                      debtMode === "collect"
-+                        ? setDebtCycleTagValue(event.target.value)
-+                        : setDebtTagValue(event.target.value)
-+                    }
-+                    className={`w-full rounded-md px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 ${
-+                      debtMode === "collect"
-+                        ? "border border-emerald-200 focus:border-emerald-500 focus:ring-emerald-200"
-+                        : "border border-amber-200 focus:border-amber-500 focus:ring-amber-200"
-+                    }`}
-+                    placeholder={t(
-+                      debtMode === "collect"
-+                        ? "transactionForm.debt.cyclePlaceholder"
-+                        : "transactionForm.debt.tagPlaceholder"
-+                    )}
-+                  />
-+                  <datalist id={debtTagListId}>
-+                    {recentDebtTags.map((tag) => (
-+                      <option key={tag} value={tag} />
-+                    ))}
-+                  </datalist>
-+                  <p
-+                    className={`text-xs ${
-+                      debtMode === "collect" ? "text-emerald-700" : "text-amber-700"
-+                    }`}
-+                  >
-+                    {t(
-+                      debtMode === "collect"
-+                        ? "transactionForm.debt.cycleHelper"
-+                        : "transactionForm.debt.tagHelper"
-+                    )}
-+                  </p>
-+                </div>
-+                {debtMode === "lend" ? (
-+                  <label className="inline-flex items-center gap-2 rounded-md border border-amber-200 bg-white px-3 py-2 text-sm font-medium text-amber-700 shadow-sm">
-+                    <input
-+                      type="checkbox"
-+                      className="h-4 w-4 rounded border-amber-300 text-amber-600 focus:ring-amber-500"
-+                      checked={useLastMonthTag}
-+                      onChange={(event) => handleToggleLastMonth(event.target.checked)}
-+                    />
-+                    {t("transactionForm.debt.lastMonthToggle")}
-+                  </label>
-+                ) : null}
-+              </div>
-             </div>
- 
-             {debtMode === "lend" ? (
-               <CustomSelect
-                 label={t("transactionForm.labels.withdrawFromAccount")}
-                 value={fromAccountId}
-                 onChange={setFromAccountId}
-                 options={accountsWithOptions}
-                 required
-                 onAddNew={handleAddAccount}
-                 addNewLabel={t("transactionForm.addAccount")}
-               />
-             ) : (
-               <CustomSelect
-                 label={t("transactionForm.labels.toAccount")}
-                 value={toAccountId}
-                 onChange={setToAccountId}
-                 options={bankAccountOptions.length > 0 ? bankAccountOptions : accountsWithOptions}
-                 required
-                 onAddNew={handleAddAccount}
-                 addNewLabel={t("transactionForm.addAccount")}
-               />
-             )}
-           </>
-         )}
- 
-         {shouldShowShopSection && (
-           <div className="rounded-lg border border-emerald-200 bg-emerald-50 shadow-sm">
-             <div className="border-b border-emerald-100 bg-emerald-100/60 px-4 py-3">
-               <p className="text-sm font-semibold text-emerald-800">
-                 {t("transactionForm.shop.sectionTitle")}
-               </p>
-               <p className="text-xs text-emerald-700">{t("transactionForm.shop.helper")}</p>
-             </div>
-             <div className="p-4">
-               <CustomSelect
-                 label={t("transactionForm.shop.shopLabel")}
-                 value={shopId}
--                onChange={(value) => {
--                  if (value === "__add_new__") {
--                    handleAddShop();
--                    return;
--                  }
--                  setShopId(value);
--                }}
-+                onChange={setShopId}
-                 options={shopOptions}
-                 onAddNew={handleAddShop}
-                 addNewLabel={t("transactionForm.shop.addShop")}
-               />
-             </div>
-           </div>
-         )}
- 
-         <div>
-           <label className="block text-sm font-medium text-gray-700">{t("common.notes")}</label>
-           <textarea
-             value={notes}
-             onChange={(e) => setNotes(e.target.value)}
-             rows={3}
-             className="mt-1 block w-full rounded-md border border-gray-300 px-4 py-3 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-           />
-         </div>
- 
-         <div
-           className={`flex flex-shrink-0 flex-col gap-3 border-t border-gray-200 px-6 py-4 md:flex-row md:items-center md:justify-between ${
-             layout === "modal" ? "bg-white" : "bg-gray-50 pt-4"
-           }`}
-         >
-           <button
-             type="button"
-             onClick={handleBack}
-             className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
-           >
-             <ArrowLeftIcon />
-             {t("common.back")}
-           </button>
-           <button
-             type="submit"
-             disabled={isSubmitting}
-             className="inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-6 py-3 text-base font-medium text-white shadow-sm transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-60"
-           >
-             {isSubmitting ? t("transactionForm.actions.submitting") : t("transactionForm.actions.submit")}
-           </button>
-         </div>
-       </div>
-       <ConfirmDialog
-         open={showLeaveDialog}
-         title={t("transactionForm.confirmLeaveTitle")}
-         description={t("transactionForm.confirmLeave")}
-         cancelLabel={t("common.cancel")}
-         confirmLabel={t("common.confirm")}
-         onCancel={handleCancelLeave}
-         onConfirm={handleConfirmLeave}
-       />
--    </form>
-+      </form>
-+      <AddShopModal open={isShopModalOpen} onClose={handleCloseShopModal} onCreate={handleCreateShopRecord} />
-+    </>
-   );
- }
- 
- const ArrowLeftIcon = () => (
-   <svg
-     xmlns="http://www.w3.org/2000/svg"
-     viewBox="0 0 20 20"
-     fill="none"
-     stroke="currentColor"
-     strokeWidth={1.5}
-     className="h-4 w-4"
-   >
-     <path d="M12.5 5 7.5 10l5 5" strokeLinecap="round" strokeLinejoin="round" />
-     <path d="M12.5 10H4" strokeLinecap="round" strokeLinejoin="round" />
-   </svg>
- );
- 
- const CloseIcon = () => (
-   <svg
-     xmlns="http://www.w3.org/2000/svg"
-     viewBox="0 0 20 20"
-     fill="none"
-     stroke="currentColor"
-     strokeWidth={1.5}
-     className="h-5 w-5"
+"use client";
+
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Account, Subcategory, Person, Shop } from "./formData";
+import { createTransaction, updateTransaction } from "../actions";
+import AmountInput from "@/components/forms/AmountInput";
+import CustomSelect from "@/components/forms/CustomSelect";
+import CashbackInput from "@/components/forms/CashbackInput";
+import { createTranslator } from "@/lib/i18n";
+import { normalizeTransactionNature, type TransactionNatureCode } from "@/lib/transactionNature";
+import { useAppShell } from "@/components/AppShellProvider";
+import ConfirmDialog from "@/components/ui/ConfirmDialog";
+import { formatDateTag } from "@/lib/dateTag";
+import AddShopModal from "@/components/shops/AddShopModal";
+import type { TransactionListItem } from "../types";
+
+type Tab = "expense" | "income" | "transfer" | "debt";
+type DebtMode = "collect" | "lend";
+
+type TransactionFormProps = {
+  accounts: Account[];
+  subcategories: Subcategory[];
+  people: Person[];
+  shops: Shop[];
+  returnTo: string;
+  createdSubcategoryId?: string;
+  initialTab?: Tab;
+  initialTransaction?: TransactionListItem;
+  mode?: "create" | "edit";
+  onClose?: () => void;
+  layout?: "page" | "modal";
+};
+
+type CashbackSource = "percent" | "amount" | null;
+type CashbackInfo = { percent: number; amount: number; source: CashbackSource };
+
+type PersistedState = {
+  activeTab: Tab;
+  amount: string;
+  fromAccountId: string;
+  toAccountId: string;
+  subcategoryId: string;
+  personId: string;
+  notes: string;
+  date: string;
+  cashbackPercent: number;
+  cashbackAmount: number;
+  cashbackSource: CashbackSource;
+  debtMode: DebtMode;
+  shopId: string;
+  debtTag: string;
+  debtCycleTag: string;
+  useLastMonthTag: boolean;
+};
+
+const STORAGE_KEY = "transactions:add-form-state";
+const PRESERVE_KEY = `${STORAGE_KEY}:preserve`;
+
+const tabColors: Record<Tab, string> = {
+  expense: "bg-red-500",
+  income: "bg-green-500",
+  transfer: "bg-blue-500",
+  debt: "bg-yellow-500",
+};
+
+const debtModePalette: Record<DebtMode, { active: string; inactive: string }> = {
+  lend: {
+    active: "bg-rose-500 text-white shadow",
+    inactive: "border border-rose-300 bg-white text-rose-700 hover:bg-rose-50",
+  },
+  collect: {
+    active: "bg-emerald-500 text-white shadow",
+    inactive: "border border-emerald-300 bg-white text-emerald-700 hover:bg-emerald-50",
+  },
+};
+
+const TabButton = ({
+  title,
+  color,
+  active,
+  onClick,
+}: {
+  title: string;
+  color: string;
+  active: boolean;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={[
+      "inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm transition",
+      active ? color : "bg-gray-300 hover:bg-gray-400",
+    ].join(" ")}
+    aria-pressed={active}
+  >
+    {title}
+  </button>
+);
+
+const toDateInputValue = (isoLike: string) => {
+  try {
+    const d = new Date(isoLike);
+    if (Number.isNaN(d.getTime())) return new Date().toISOString().split("T")[0];
+    return d.toISOString().split("T")[0];
+  } catch {
+    return new Date().toISOString().split("T")[0];
+  }
+};
+
+const mapNatureToTab = (code: TransactionNatureCode | null): Tab | null => {
+  if (!code) return null;
+  if (code === "EX") return "expense";
+  if (code === "IN") return "income";
+  if (code === "TF") return "transfer";
+  if (code === "DE") return "debt";
+  return null;
+};
+
+const readStringField = (record: TransactionListItem | null, field: string): string | null => {
+  if (!record) {
+    return null;
+  }
+  const value = (record as Record<string, unknown>)[field];
+  return typeof value === "string" && value.trim() ? value : null;
+};
+
+const readNumberField = (record: TransactionListItem | null, field: string): number | null => {
+  if (!record) {
+    return null;
+  }
+  const value = (record as Record<string, unknown>)[field];
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const determineTabFromTransactionRecord = (tx: TransactionListItem): Tab => {
+  const rawNature = tx.transactionNature ?? readStringField(tx, "transaction_nature");
+  const code = normalizeTransactionNature(rawNature ?? null);
+  return mapNatureToTab(code) ?? "expense";
+};
+
+const extractCashbackInfoFromTransaction = (
+  tx: TransactionListItem
+): { info: CashbackInfo; show: boolean } => {
+  const percentValue =
+    (typeof tx.cashbackPercent === "number" && Number.isFinite(tx.cashbackPercent)
+      ? tx.cashbackPercent
+      : null) ?? readNumberField(tx, "cashback_percent") ?? 0;
+  const amountValue =
+    (typeof tx.cashbackAmount === "number" && Number.isFinite(tx.cashbackAmount)
+      ? tx.cashbackAmount
+      : null) ?? readNumberField(tx, "cashback_amount") ?? 0;
+  const derivedSource: CashbackSource =
+    amountValue > 0 ? "amount" : percentValue > 0 ? "percent" : null;
+  return {
+    info: { percent: percentValue, amount: amountValue, source: derivedSource },
+    show: percentValue > 0 || amountValue > 0,
+  };
+};
+
+const formatAmountForInput = (value: number | null | undefined) => {
+  if (value == null || Number.isNaN(value)) {
+    return "";
+  }
+  return Math.round(value).toLocaleString("en-US");
+};
+
+const resolveDebtModeFromTransaction = (record: TransactionListItem | null): DebtMode => {
+  const rawMode = (record ? readStringField(record, "debtMode") ?? readStringField(record, "debt_mode") : null) ?? null;
+  return rawMode === "collect" ? "collect" : "lend";
+};
+
+export default function TransactionForm({
+  accounts,
+  subcategories,
+  people,
+  shops,
+  returnTo,
+  createdSubcategoryId,
+  initialTab,
+  initialTransaction,
+  mode = "create",
+  onClose,
+  layout = "page",
+}: TransactionFormProps) {
+  const t = createTranslator();
+  const router = useRouter();
+  const { showSuccess, navigate } = useAppShell();
+
+  const isEditMode = mode === "edit";
+  const editingTransaction = isEditMode && initialTransaction ? initialTransaction : null;
+
+  // Restore persisted state (create mode)
+  const persistedStateRef = useRef<PersistedState | null>(null);
+  if (!isEditMode && persistedStateRef.current === null && typeof window !== "undefined") {
+    try {
+      const shouldPreserve = sessionStorage.getItem(PRESERVE_KEY) === "1";
+      const raw = sessionStorage.getItem(STORAGE_KEY);
+      if (!shouldPreserve) {
+        sessionStorage.removeItem(STORAGE_KEY);
+      } else {
+        sessionStorage.removeItem(PRESERVE_KEY);
+      }
+      if (raw && shouldPreserve) {
+        const parsed = JSON.parse(raw) as Partial<PersistedState>;
+        const today = new Date().toISOString().split("T")[0];
+        const fallbackTag = formatDateTag(new Date()) ?? "";
+        persistedStateRef.current = {
+          activeTab: parsed.activeTab ?? "expense",
+          amount: parsed.amount ?? "",
+          fromAccountId: parsed.fromAccountId ?? "",
+          toAccountId: parsed.toAccountId ?? "",
+          subcategoryId: parsed.subcategoryId ?? "",
+          personId: parsed.personId ?? "",
+          notes: parsed.notes ?? "",
+          date: parsed.date ?? today,
+          cashbackPercent: parsed.cashbackPercent ?? 0,
+          cashbackAmount: parsed.cashbackAmount ?? 0,
+          cashbackSource:
+            parsed.cashbackSource === "percent" || parsed.cashbackSource === "amount"
+              ? parsed.cashbackSource
+              : null,
+          debtMode: parsed.debtMode === "collect" ? "collect" : "lend",
+          shopId: parsed.shopId ?? "",
+          debtTag: typeof parsed.debtTag === "string" ? parsed.debtTag : fallbackTag,
+          debtCycleTag:
+            typeof parsed.debtCycleTag === "string" ? parsed.debtCycleTag : fallbackTag,
+          useLastMonthTag: Boolean(parsed.useLastMonthTag),
+        };
+      }
+    } catch {
+      persistedStateRef.current = null;
+    }
+  }
+  const persistedState = isEditMode ? null : persistedStateRef.current;
+
+  // Defaults
+  const defaultTabValue: Tab = editingTransaction
+    ? determineTabFromTransactionRecord(editingTransaction)
+    : persistedState?.activeTab ?? initialTab ?? "expense";
+
+  const { info: editingCashbackInfo, show: editingShowCashback } = editingTransaction
+    ? extractCashbackInfoFromTransaction(editingTransaction)
+    : { info: { percent: 0, amount: 0, source: null }, show: false };
+
+  const defaultAmount = editingTransaction
+    ? formatAmountForInput(editingTransaction.amount)
+    : persistedState?.amount ?? "";
+  const defaultFromAccount = editingTransaction?.fromAccountId ?? persistedState?.fromAccountId ?? "";
+  const defaultToAccount = editingTransaction?.toAccountId ?? persistedState?.toAccountId ?? "";
+  const defaultSubcategory = editingTransaction?.subcategoryId ?? persistedState?.subcategoryId ?? "";
+  const defaultPerson = editingTransaction?.personId ?? persistedState?.personId ?? "";
+  const defaultNotes = editingTransaction?.notes ?? persistedState?.notes ?? "";
+  const defaultDate = editingTransaction
+    ? toDateInputValue(editingTransaction.date)
+    : persistedState?.date ?? new Date().toISOString().split("T")[0];
+  const defaultCashbackPercent = editingTransaction ? editingCashbackInfo.percent : persistedState?.cashbackPercent ?? 0;
+  const defaultCashbackAmount = editingTransaction ? editingCashbackInfo.amount : persistedState?.cashbackAmount ?? 0;
+  const defaultCashbackSource: CashbackSource = editingTransaction
+    ? editingCashbackInfo.source
+    : persistedState?.cashbackSource ?? null;
+  const defaultDebtMode: DebtMode =
+    editingTransaction && defaultTabValue === "debt"
+      ? resolveDebtModeFromTransaction(editingTransaction)
+      : persistedState?.debtMode ?? "lend";
+  const defaultShopId = editingTransaction?.shopId ?? persistedState?.shopId ?? "";
+
+  const fallbackDebtTag = formatDateTag(editingTransaction?.date ?? new Date()) ?? "";
+  const defaultDebtTag = editingTransaction?.debtTag ?? persistedState?.debtTag ?? fallbackDebtTag;
+  const defaultDebtCycleTag = editingTransaction?.debtCycleTag ?? persistedState?.debtCycleTag ?? fallbackDebtTag;
+  const defaultUseLastMonthTag = persistedState?.useLastMonthTag ?? false;
+
+  // State
+  const [activeTab, setActiveTab] = useState<Tab>(defaultTabValue);
+  const [amount, setAmount] = useState(defaultAmount);
+  const [fromAccountId, setFromAccountId] = useState(defaultFromAccount);
+  const [toAccountId, setToAccountId] = useState(defaultToAccount);
+  const [subcategoryId, setSubcategoryId] = useState(defaultSubcategory);
+  const [personId, setPersonId] = useState(defaultPerson);
+  const [notes, setNotes] = useState(defaultNotes);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [date, setDate] = useState(defaultDate);
+  const [debtMode, setDebtMode] = useState<DebtMode>(defaultDebtMode);
+  const [shopId, setShopId] = useState(defaultShopId);
+  const [showLeaveDialog, setShowLeaveDialog] = useState(false);
+
+  // Debt tags
+  const [debtTagValue, setDebtTagValue] = useState(defaultDebtTag);
+  const [debtCycleTagValue, setDebtCycleTagValue] = useState(defaultDebtCycleTag);
+  const [useLastMonthTag, setUseLastMonthTag] = useState(defaultUseLastMonthTag);
+
+  // Local shop cache + modal
+  const [shopRecords, setShopRecords] = useState<Shop[]>(() => shops);
+  const [isShopModalOpen, setShopModalOpen] = useState(false);
+
+  const [showCashback, setShowCashback] = useState(() => (isEditMode ? editingShowCashback : false));
+  const [selectedAccount, setSelectedAccount] = useState<Account | null>(() => {
+    if (defaultFromAccount) {
+      return accounts.find((a) => a.id === defaultFromAccount) ?? null;
+    }
+    return null;
+  });
+  const [cashbackInfo, setCashbackInfo] = useState<CashbackInfo>({
+    percent: defaultCashbackPercent,
+    amount: defaultCashbackAmount,
+    source: defaultCashbackSource,
+  });
+
+  // IDs for inputs
+  const debtTagInputId = useId();
+  const debtCycleInputId = useId();
+  const debtTagListId = useId();
+
+  // Helpers
+  const mapToOptions = useCallback(
+    (item: {
+      id: string;
+      name: string;
+      image_url?: string | null;
+      type?: string | null;
+      is_group?: boolean | null;
+    }) => ({
+      id: item.id,
+      name: item.name,
+      imageUrl: item.image_url || undefined,
+      type:
+        item.type ||
+        (typeof item.is_group === "boolean" ? (item.is_group ? "Group" : "Individual") : undefined),
+    }),
+    []
+  );
+
+  const generateShopId = useCallback(() => {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID();
+    }
+    return `shop-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  }, []);
+
+  const getTransactionNature = useCallback((sub: Subcategory): TransactionNatureCode | null => {
+    const direct = normalizeTransactionNature(sub.transaction_nature ?? null);
+    if (direct) return direct;
+    if (!sub.categories) return null;
+    if (Array.isArray(sub.categories)) {
+      return normalizeTransactionNature(sub.categories[0]?.transaction_nature ?? null);
+    }
+    return null;
+  }, []);
+
+
+  // Options
+  const expenseCategories = useMemo(
+    () => subcategories.filter((s) => getTransactionNature(s) === "EX").map(mapToOptions),
+    [subcategories, getTransactionNature, mapToOptions]
+  );
+  const incomeCategories = useMemo(
+    () => subcategories.filter((s) => getTransactionNature(s) === "IN").map(mapToOptions),
+    [subcategories, getTransactionNature, mapToOptions]
+  );
+  const accountsWithOptions = useMemo(() => accounts.map(mapToOptions), [accounts, mapToOptions]);
+  const bankAccountOptions = useMemo(
+    () => accounts.filter((a) => a.type?.toLowerCase() === "bank").map(mapToOptions),
+    [accounts, mapToOptions]
+  );
+  const peopleWithOptions = useMemo(() => people.map(mapToOptions), [people, mapToOptions]);
+  const shopOptions = useMemo(() => shopRecords.map(mapToOptions), [mapToOptions, shopRecords]);
+
+  const selectedSubcategory = useMemo(
+    () => (subcategoryId ? subcategories.find((s) => s.id === subcategoryId) ?? null : null),
+    [subcategoryId, subcategories]
+  );
+
+  const isShopCategory = selectedSubcategory?.is_shop ?? false;
+
+  const shouldShowShopSection = useMemo(() => {
+    if (activeTab === "debt") return true;
+    if (activeTab === "expense" || activeTab === "income") return Boolean(isShopCategory || shopId);
+    if (activeTab === "transfer") return Boolean(shopId);
+    return false;
+  }, [activeTab, isShopCategory, shopId]);
+
+  // Keep shop section and accounts consistent when switching tabs
+  useEffect(() => {
+    if (!shouldShowShopSection && shopId) setShopId("");
+  }, [shouldShowShopSection, shopId]);
+
+  useEffect(() => {
+    if (activeTab === "transfer") {
+      setSubcategoryId("");
+      if (!fromAccountId && accounts.length > 0) setFromAccountId(accounts[0].id);
+      if (!toAccountId && bankAccountOptions.length > 0) setToAccountId(bankAccountOptions[0].id);
+    } else if (activeTab === "debt") {
+      setSubcategoryId("");
+      if (debtMode === "lend") {
+        setToAccountId("");
+        if (!fromAccountId && accounts.length > 0) setFromAccountId(accounts[0].id);
+      } else {
+        setFromAccountId("");
+        if (!toAccountId && bankAccountOptions.length > 0) setToAccountId(bankAccountOptions[0].id);
+      }
+    } else {
+      // expense | income
+      setToAccountId("");
+    }
+  }, [activeTab, bankAccountOptions, debtMode, accounts, fromAccountId, toAccountId]);
+
+  // Created subcategory flow
+  const mapNatureToTabLocal = useCallback((code: TransactionNatureCode | null) => {
+    const m = mapNatureToTab(code);
+    return m ?? "expense";
+  }, []);
+  useEffect(() => {
+    if (!createdSubcategoryId) return;
+    const newly = subcategories.find((s) => s.id === createdSubcategoryId);
+    if (!newly) return;
+    setSubcategoryId(createdSubcategoryId);
+    const mappedTab = mapNatureToTabLocal(getTransactionNature(newly));
+    if (mappedTab && mappedTab !== activeTab) setActiveTab(mappedTab);
+  }, [createdSubcategoryId, subcategories, mapNatureToTabLocal, getTransactionNature, activeTab]);
+
+  // Cashback visibility
+  useEffect(() => {
+    const account = accounts.find((a) => a.id === fromAccountId) ?? null;
+    setSelectedAccount(account);
+    const shouldEnableCashback =
+      Boolean(account?.is_cashback_eligible) ||
+      (isEditMode &&
+        editingTransaction &&
+        editingTransaction.fromAccountId === account?.id &&
+        editingShowCashback);
+    if (shouldEnableCashback) {
+      setShowCashback(true);
+    } else {
+      setShowCashback(false);
+      setCashbackInfo({ percent: 0, amount: 0, source: null });
+    }
+  }, [accounts, fromAccountId, editingShowCashback, editingTransaction, isEditMode]);
+
+  // Merge incoming shops -> local cache (avoid dup id)
+  useEffect(() => {
+    setShopRecords((prev) => {
+      const existing = new Set(prev.map((s) => s.id));
+      const merged = [...prev];
+      shops.forEach((s) => {
+        if (!existing.has(s.id)) merged.push(s);
+      });
+      return merged;
+    });
+  }, [shops]);
+
+  // Debt-tag logic
+  const recentDebtTags = useMemo(() => {
+    const tags = new Set<string>();
+    const add = (v?: string | null) => {
+      const trimmed = (v ?? "").trim();
+      if (trimmed) tags.add(trimmed);
+    };
+    for (let i = 0; i < 6; i += 1) {
+      const d = new Date();
+      d.setMonth(d.getMonth() - i, 1);
+      add(formatDateTag(d));
+    }
+    add(debtTagValue);
+    add(debtCycleTagValue);
+    return Array.from(tags);
+  }, [debtTagValue, debtCycleTagValue]);
+
+  useEffect(() => {
+    if (debtMode === "collect" && useLastMonthTag) setUseLastMonthTag(false);
+  }, [debtMode, useLastMonthTag]);
+
+  useEffect(() => {
+    if (debtMode === "collect" && !debtCycleTagValue.trim()) {
+      setDebtCycleTagValue(formatDateTag(new Date()) ?? "");
+    }
+    if (debtMode === "lend" && !debtTagValue.trim()) {
+      setDebtTagValue(formatDateTag(new Date()) ?? "");
+    }
+  }, [debtMode, debtCycleTagValue, debtTagValue]);
+
+  const initialSnapshotRef = useRef<PersistedState>({
+    activeTab: defaultTabValue,
+    amount: defaultAmount,
+    fromAccountId: defaultFromAccount,
+    toAccountId: defaultToAccount,
+    subcategoryId: defaultSubcategory,
+    personId: defaultPerson,
+    notes: defaultNotes,
+    date: defaultDate,
+    cashbackPercent: defaultCashbackPercent,
+    cashbackAmount: defaultCashbackAmount,
+    cashbackSource: defaultCashbackSource,
+    debtMode: defaultDebtMode,
+    shopId: defaultShopId,
+    debtTag: defaultDebtTag,
+    debtCycleTag: defaultDebtCycleTag,
+    useLastMonthTag: defaultUseLastMonthTag,
+  });
+
+  const isDirty = useMemo(() => {
+    const s = initialSnapshotRef.current;
+    return (
+      s.activeTab !== activeTab ||
+      s.amount !== amount ||
+      s.fromAccountId !== fromAccountId ||
+      s.toAccountId !== toAccountId ||
+      s.subcategoryId !== subcategoryId ||
+      s.personId !== personId ||
+      s.notes !== notes ||
+      s.date !== date ||
+      s.cashbackPercent !== cashbackInfo.percent ||
+      s.cashbackAmount !== cashbackInfo.amount ||
+      s.cashbackSource !== cashbackInfo.source ||
+      s.debtMode !== debtMode ||
+      s.shopId !== shopId ||
+      s.debtTag !== debtTagValue ||
+      s.debtCycleTag !== debtCycleTagValue ||
+      s.useLastMonthTag !== useLastMonthTag
+    );
+  }, [
+    activeTab,
+    amount,
+    fromAccountId,
+    toAccountId,
+    subcategoryId,
+    personId,
+    notes,
+    date,
+    cashbackInfo,
+    debtMode,
+    shopId,
+    debtTagValue,
+    debtCycleTagValue,
+    useLastMonthTag,
+  ]);
+
+  const completeNavigation = useCallback(() => {
+    if (typeof window !== "undefined") {
+      sessionStorage.removeItem(STORAGE_KEY);
+      sessionStorage.removeItem(PRESERVE_KEY);
+    }
+    if (onClose) onClose();
+    navigate(returnTo);
+  }, [navigate, onClose, returnTo]);
+
+  const handleBack = useCallback(() => {
+    if (isDirty) {
+      setShowLeaveDialog(true);
+      return;
+    }
+    completeNavigation();
+  }, [completeNavigation, isDirty]);
+
+  const handleConfirmLeave = useCallback(() => {
+    setShowLeaveDialog(false);
+    completeNavigation();
+  }, [completeNavigation]);
+
+  const handleCancelLeave = useCallback(() => setShowLeaveDialog(false), []);
+
+  // Persist on change (create mode)
+  useEffect(() => {
+    if (typeof window === "undefined" || isEditMode) return;
+    const payload: PersistedState = {
+      activeTab,
+      amount,
+      fromAccountId,
+      toAccountId,
+      subcategoryId,
+      personId,
+      notes,
+      date,
+      cashbackPercent: cashbackInfo.percent,
+      cashbackAmount: cashbackInfo.amount,
+      cashbackSource: cashbackInfo.source,
+      debtMode,
+      shopId,
+      debtTag: debtTagValue,
+      debtCycleTag: debtCycleTagValue,
+      useLastMonthTag,
+    };
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    persistedStateRef.current = payload;
+  }, [
+    activeTab,
+    amount,
+    cashbackInfo,
+    debtMode,
+    fromAccountId,
+    isEditMode,
+    notes,
+    personId,
+    shopId,
+    subcategoryId,
+    toAccountId,
+    date,
+    debtTagValue,
+    debtCycleTagValue,
+    useLastMonthTag,
+  ]);
+
+  // Actions
+  const addCategoryLabel = useMemo(() => {
+    switch (activeTab) {
+      case "income":
+        return t("transactionForm.addCategory.income");
+      case "transfer":
+        return t("transactionForm.addCategory.transfer");
+      case "debt":
+        return t("transactionForm.addCategory.debt");
+      default:
+        return t("transactionForm.addCategory.expense");
+    }
+  }, [activeTab, t]);
+
+  const handleAddAccount = useCallback(() => {
+    alert(t("transactionForm.addAccountPlaceholder"));
+  }, [t]);
+
+  const handleAddShop = useCallback(() => setShopModalOpen(true), []);
+
+  const handleCreateShopRecord = useCallback(
+    (values: { name: string; type?: string; notes?: string | null }) => {
+      const id = generateShopId();
+      const record: Shop = {
+        id,
+        name: values.name,
+        image_url: null,
+        type: values.type ? values.type.toLowerCase() : null,
+        created_at: new Date().toISOString(),
+      };
+      setShopRecords((prev) => [record, ...prev]);
+      setShopId(id);
+      setShopModalOpen(false);
+      showSuccess(t("shops.actions.addNew"));
+    },
+    [generateShopId, showSuccess, t]
+  );
+
+  const handleCloseShopModal = useCallback(() => setShopModalOpen(false), []);
+
+  const returnPath = useMemo(() => {
+    const params = new URLSearchParams();
+    params.set("tab", activeTab);
+    const query = params.toString();
+    return query ? `/transactions/add?${query}` : "/transactions/add";
+  }, [activeTab]);
+
+  const handleAddCategory = useCallback(() => {
+    const natureMap: Record<Tab, string> = {
+      expense: "EX",
+      income: "IN",
+      transfer: "TF",
+      debt: "DE",
+    };
+    if (typeof window !== "undefined") {
+      sessionStorage.setItem(PRESERVE_KEY, "1");
+    }
+    const params = new URLSearchParams({
+      defaultNature: natureMap[activeTab],
+    });
+    params.set("returnTo", encodeURIComponent(returnPath));
+    router.push(`/categories/add?${params.toString()}`);
+  }, [activeTab, returnPath, router]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (activeTab === "transfer" && fromAccountId && fromAccountId === toAccountId) {
+      alert(t("transactionForm.errors.sameTransferAccount"));
+      return;
+    }
+    setIsSubmitting(true);
+
+    const sanitizedCashback = showCashback
+      ? {
+          percent: Number.isFinite(cashbackInfo.percent) ? Number(cashbackInfo.percent) : 0,
+          amount: Number.isFinite(cashbackInfo.amount) ? Number(cashbackInfo.amount) : 0,
+          source: cashbackInfo.source,
+        }
+      : null;
+
+    const preparedFromAccountId = activeTab === "debt" && debtMode === "collect" ? "" : fromAccountId;
+    const preparedToAccountId = activeTab === "debt" && debtMode === "lend" ? "" : toAccountId;
+
+    const normalizedNotes = notes?.trim() ? notes.trim() : null;
+
+    const payload = {
+      activeTab,
+      amount: parseFloat(amount.replace(/,/g, "")),
+      notes: normalizedNotes,
+      fromAccountId: preparedFromAccountId?.trim() ? preparedFromAccountId.trim() : undefined,
+      toAccountId: preparedToAccountId?.trim() ? preparedToAccountId.trim() : undefined,
+      subcategoryId: subcategoryId?.trim() ? subcategoryId.trim() : undefined,
+      personId: personId?.trim() ? personId.trim() : undefined,
+      date,
+      cashback: sanitizedCashback,
+      debtMode,
+      shopId: shopId?.trim() ? shopId.trim() : undefined,
+      debtTag:
+        activeTab === "debt" && debtMode !== "collect"
+          ? debtTagValue.trim() || undefined
+          : undefined,
+      debtCycleTag:
+        activeTab === "debt" && debtMode === "collect"
+          ? debtCycleTagValue.trim() || undefined
+          : undefined,
+    };
+
+    const result =
+      isEditMode && editingTransaction
+        ? await updateTransaction({ id: editingTransaction.id, ...payload })
+        : await createTransaction(payload);
+
+    setIsSubmitting(false);
+
+    if (!result.success) {
+      alert(result.message);
+      return;
+    }
+
+    if (typeof window !== "undefined") {
+      sessionStorage.removeItem(STORAGE_KEY);
+      sessionStorage.removeItem(PRESERVE_KEY);
+    }
+
+    showSuccess(result.message);
+    navigate(returnTo);
+  };
+
+  // Unmount cleanup for create mode
+  useEffect(() => {
+    if (isEditMode) return () => undefined;
+    return () => {
+      if (typeof window !== "undefined") {
+        const shouldPreserve = sessionStorage.getItem(PRESERVE_KEY) === "1";
+        if (!shouldPreserve) {
+          sessionStorage.removeItem(STORAGE_KEY);
+          sessionStorage.removeItem(PRESERVE_KEY);
+        }
+      }
+    };
+  }, [isEditMode]);
+
+  // UI wrappers
+  const formClasses =
+    layout === "modal"
+      ? "flex h-full min-h-0 flex-col overflow-hidden"
+      : "overflow-hidden rounded-lg border border-gray-200 shadow-sm";
+
+  const contentWrapperClasses =
+    layout === "modal"
+      ? "flex-1 min-h-0 overflow-y-auto bg-white p-6 space-y-6"
+      : "space-y-6 bg-white p-6";
+
+  const dateTag = useMemo(() => formatDateTag(date), [date]);
+
+  return (
+    <>
+      <form onSubmit={handleSubmit} className={formClasses}>
+        {layout === "modal" ? (
+          <div className="flex flex-shrink-0 items-center justify-between border-b border-gray-200 bg-white px-6 py-4">
+            <button
+              type="button"
+              onClick={handleBack}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-gray-300 text-gray-600 transition hover:bg-gray-100"
+              aria-label={t("common.close")}
+            >
+              <CloseIcon />
+            </button>
+            <h2 className="text-lg font-semibold text-gray-900">
+              {t("transactionForm.title")}
+            </h2>
+            <span className="h-9 w-9" aria-hidden="true" />
+          </div>
+        ) : null}
+
+        {/* Tabs */}
+        <div className="flex flex-shrink-0 flex-col gap-3 border-b border-gray-200 bg-gray-50 px-6 py-4 md:flex-row md:items-center md:justify-between">
+          <div className="grid flex-1 grid-cols-2 gap-2 md:grid-cols-4">
+            <TabButton
+              title={t("transactionForm.tabs.expense")}
+              active={activeTab === "expense"}
+              color={tabColors.expense}
+              onClick={() => setActiveTab("expense")}
+            />
+            <TabButton
+              title={t("transactionForm.tabs.income")}
+              active={activeTab === "income"}
+              color={tabColors.income}
+              onClick={() => setActiveTab("income")}
+            />
+            <TabButton
+              title={t("transactionForm.tabs.transfer")}
+              active={activeTab === "transfer"}
+              color={tabColors.transfer}
+              onClick={() => setActiveTab("transfer")}
+            />
+            <TabButton
+              title={t("transactionForm.tabs.debt")}
+              active={activeTab === "debt"}
+              color={tabColors.debt}
+              onClick={() => setActiveTab("debt")}
+            />
+          </div>
+        </div>
+
+        <div className={contentWrapperClasses}>
+          {/* Amount + Date */}
+          <div className="grid gap-6 md:grid-cols-2">
+            <AmountInput value={amount} onChange={setAmount} />
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                {t("common.date")}
+              </label>
+              <input
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-4 py-3 text-base shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+              />
+              {activeTab !== "debt" && dateTag ? (
+                <div className="mt-2">
+                  <span className="inline-flex items-center rounded-full border border-indigo-200 bg-indigo-50 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-indigo-700">
+                    {dateTag}
+                  </span>
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          {/* Tab bodies */}
+          {activeTab === "expense" && (
+            <>
+              <CustomSelect
+                label={t("transactionForm.labels.fromAccount")}
+                value={fromAccountId}
+                onChange={setFromAccountId}
+                options={accountsWithOptions}
+                required
+                onAddNew={handleAddAccount}
+                addNewLabel={t("transactionForm.addAccount")}
+              />
+
+              {showCashback && selectedAccount && (
+                <CashbackInput
+                  transactionAmount={amount}
+                  account={selectedAccount}
+                  value={cashbackInfo}
+                  onChange={setCashbackInfo}
+                />
+              )}
+
+              <CustomSelect
+                label={t("transactionForm.labels.expenseCategory")}
+                value={subcategoryId}
+                onChange={setSubcategoryId}
+                options={expenseCategories}
+                onAddNew={handleAddCategory}
+                addNewLabel={addCategoryLabel}
+              />
+            </>
+          )}
+
+          {activeTab === "income" && (
+            <>
+              <CustomSelect
+                label={t("transactionForm.labels.toAccount")}
+                value={toAccountId}
+                onChange={setToAccountId}
+                options={accountsWithOptions}
+                required
+                onAddNew={handleAddAccount}
+                addNewLabel={t("transactionForm.addAccount")}
+              />
+              <CustomSelect
+                label={t("transactionForm.labels.incomeCategory")}
+                value={subcategoryId}
+                onChange={setSubcategoryId}
+                options={incomeCategories}
+                onAddNew={handleAddCategory}
+                addNewLabel={addCategoryLabel}
+              />
+            </>
+          )}
+
+          {activeTab === "transfer" && (
+            <>
+              <div className="grid gap-4 md:grid-cols-2">
+                <CustomSelect
+                  label={t("transactionForm.labels.fromAccount")}
+                  value={fromAccountId}
+                  onChange={setFromAccountId}
+                  options={accountsWithOptions}
+                  required
+                  onAddNew={handleAddAccount}
+                  addNewLabel={t("transactionForm.addAccount")}
+                />
+                <CustomSelect
+                  label={t("transactionForm.labels.toAccount")}
+                  value={toAccountId}
+                  onChange={setToAccountId}
+                  options={accountsWithOptions}
+                  required
+                  onAddNew={handleAddAccount}
+                  addNewLabel={t("transactionForm.addAccount")}
+                />
+              </div>
+              <p className="text-xs text-indigo-600">
+                {t("transactionForm.hints.transferSameAccount")}
+              </p>
+            </>
+          )}
+
+          {activeTab === "debt" && (
+            <>
+              <CustomSelect
+                label={t("transactionForm.labels.whoOwes")}
+                value={personId}
+                onChange={setPersonId}
+                options={peopleWithOptions}
+                required
+              />
+
+              <div className="rounded-lg border border-amber-200 bg-amber-50 shadow-sm">
+                <div className="flex flex-col gap-3 border-b border-amber-100 bg-amber-100/60 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-sm font-semibold uppercase tracking-wide text-amber-900">
+                      {t("transactionForm.debt.directionTitle")}
+                    </p>
+                    <p className="text-xs text-amber-800">
+                      {t("transactionForm.debt.directionHelper")}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2 sm:gap-3">
+                    {(["lend", "collect"] as DebtMode[]).map((mode) => (
+                      <button
+                        key={mode}
+                        type="button"
+                        onClick={() => setDebtMode(mode)}
+                        className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                          debtMode === mode
+                            ? debtModePalette[mode].active
+                            : debtModePalette[mode].inactive
+                        }`}
+                        aria-pressed={debtMode === mode}
+                      >
+                        {t(`transactionForm.debtModes.${mode}` as const)}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Tag inputs */}
+                <div className="grid gap-4 px-4 py-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+                  <div className="space-y-2">
+                    <label
+                      className={`text-sm font-medium ${
+                        debtMode === "collect" ? "text-emerald-800" : "text-amber-800"
+                      }`}
+                      htmlFor={debtMode === "collect" ? debtCycleInputId : debtTagInputId}
+                    >
+                      {debtMode === "collect"
+                        ? t("transactionForm.debt.cycleLabel")
+                        : t("transactionForm.debt.tagLabel")}
+                    </label>
+                    <input
+                      id={debtMode === "collect" ? debtCycleInputId : debtTagInputId}
+                      list={debtTagListId}
+                      value={debtMode === "collect" ? debtCycleTagValue : debtTagValue}
+                      onChange={(e) =>
+                        debtMode === "collect"
+                          ? setDebtCycleTagValue(e.target.value)
+                          : setDebtTagValue(e.target.value)
+                      }
+                      className={`w-full rounded-md px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 ${
+                        debtMode === "collect"
+                          ? "border border-emerald-200 focus:border-emerald-500 focus:ring-emerald-200"
+                          : "border border-amber-200 focus:border-amber-500 focus:ring-amber-200"
+                      }`}
+                      placeholder={t(
+                        debtMode === "collect"
+                          ? "transactionForm.debt.cyclePlaceholder"
+                          : "transactionForm.debt.tagPlaceholder"
+                      )}
+                    />
+                    <datalist id={debtTagListId}>
+                      {recentDebtTags.map((tag) => (
+                        <option key={tag} value={tag} />
+                      ))}
+                    </datalist>
+                    <p
+                      className={`text-xs ${
+                        debtMode === "collect" ? "text-emerald-700" : "text-amber-700"
+                      }`}
+                    >
+                      {t(
+                        debtMode === "collect"
+                          ? "transactionForm.debt.cycleHelper"
+                          : "transactionForm.debt.tagHelper"
+                      )}
+                    </p>
+                  </div>
+
+                  {debtMode === "lend" ? (
+                    <label className="inline-flex items-center gap-2 rounded-md border border-amber-200 bg-white px-3 py-2 text-sm font-medium text-amber-700 shadow-sm">
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 rounded border-amber-300 text-amber-600 focus:ring-amber-500"
+                        checked={useLastMonthTag}
+                        onChange={(e) => {
+                          const checked = e.target.checked;
+                          setUseLastMonthTag(checked);
+                          if (checked) {
+                            const d = new Date();
+                            d.setMonth(d.getMonth() - 1, 1);
+                            setDebtTagValue(formatDateTag(d) ?? "");
+                          } else if (!debtTagValue.trim()) {
+                            setDebtTagValue(formatDateTag(new Date()) ?? "");
+                          }
+                        }}
+                      />
+                      {t("transactionForm.debt.lastMonthToggle")}
+                    </label>
+                  ) : null}
+                </div>
+              </div>
+
+              {debtMode === "lend" ? (
+                <CustomSelect
+                  label={t("transactionForm.labels.withdrawFromAccount")}
+                  value={fromAccountId}
+                  onChange={setFromAccountId}
+                  options={accountsWithOptions}
+                  required
+                  onAddNew={handleAddAccount}
+                  addNewLabel={t("transactionForm.addAccount")}
+                />
+              ) : (
+                <CustomSelect
+                  label={t("transactionForm.labels.toAccount")}
+                  value={toAccountId}
+                  onChange={setToAccountId}
+                  options={bankAccountOptions.length > 0 ? bankAccountOptions : accountsWithOptions}
+                  required
+                  onAddNew={handleAddAccount}
+                  addNewLabel={t("transactionForm.addAccount")}
+                />
+              )}
+            </>
+          )}
+
+          {/* Shop section */}
+          {shouldShowShopSection && (
+            <div className="rounded-lg border border-emerald-200 bg-emerald-50 shadow-sm">
+              <div className="border-b border-emerald-100 bg-emerald-100/60 px-4 py-3">
+                <p className="text-sm font-semibold text-emerald-800">
+                  {t("transactionForm.shop.sectionTitle")}
+                </p>
+                <p className="text-xs text-emerald-700">
+                  {t("transactionForm.shop.helper")}
+                </p>
+              </div>
+              <div className="p-4">
+                <CustomSelect
+                  label={t("transactionForm.shop.shopLabel")}
+                  value={shopId}
+                  onChange={setShopId}
+                  options={shopOptions}
+                  onAddNew={handleAddShop}
+                  addNewLabel={t("transactionForm.shop.addShop")}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Notes */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              {t("common.notes")}
+            </label>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={3}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-4 py-3 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+
+          {/* Footer */}
+          <div
+            className={`flex flex-shrink-0 flex-col gap-3 border-t border-gray-200 px-6 py-4 md:flex-row md:items-center md:justify-between ${
+              layout === "modal" ? "bg-white" : "bg-gray-50 pt-4"
+            }`}
+          >
+            <button
+              type="button"
+              onClick={handleBack}
+              className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
+            >
+              <ArrowLeftIcon />
+              {t("common.back")}
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-6 py-3 text-base font-medium text-white shadow-sm transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSubmitting
+                ? t("transactionForm.actions.submitting")
+                : t("transactionForm.actions.submit")}
+            </button>
+          </div>
+        </div>
+
+        <ConfirmDialog
+          open={showLeaveDialog}
+          title={t("transactionForm.confirmLeaveTitle")}
+          description={t("transactionForm.confirmLeave")}
+          cancelLabel={t("common.cancel")}
+          confirmLabel={t("common.confirm")}
+          onCancel={handleCancelLeave}
+          onConfirm={handleConfirmLeave}
+        />
+      </form>
+
+      {/* Create Shop inline modal */}
+      <AddShopModal
+        open={isShopModalOpen}
+        onClose={handleCloseShopModal}
+        onCreate={handleCreateShopRecord}
+      />
+    </>
+  );
+}
+
+const ArrowLeftIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 20 20"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    className="h-4 w-4"
+  >
+    <path d="M12.5 5 7.5 10l5 5" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M12.5 10H4" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const CloseIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 20 20"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    className="h-5 w-5"
+  >
+    <path d="M6 6l8 8M14 6l-8 8" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);


### PR DESCRIPTION
## Summary
- widen the transactions tag filter options to include optional disabled flags so JSX usage type checks
- remove the dependency on Google Fonts during build so the layout no longer fetches Inter at compile time
- update the cashback input to accept controlled values and keep transaction state in sync during edits

## Testing
- npm run lint
- CI=1 pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d76f4cb0388329b43b6f5d68b0b735