### PR TITLE
Fallback to mock subcategories when Supabase returns none

### DIFF
--- a/src/app/transactions/add/formData.ts
+++ b/src/app/transactions/add/formData.ts
@@ -279,7 +279,25 @@ export async function loadTransactionFormData(): Promise<FormDataResult> {
   const usingMockSubcategories = normalizedSubcategories.length === 0;
 
   if (usingMockSubcategories) {
-    normalizedSubcategories = [];
+    const { subcategories: fallbackSubcategories } = getMockTransactionFormData();
+    normalizedSubcategories = fallbackSubcategories.map((subcategory) =>
+      mapSubcategoryRecord({
+        id: subcategory.id,
+        name: subcategory.name,
+        image_url: subcategory.image_url,
+        transaction_nature: subcategory.transaction_nature,
+        is_shop: subcategory.is_shop ?? false,
+        categories: subcategory.categories,
+      })
+    );
+
+    const includesTransfer = normalizedSubcategories.some(
+      (subcategory) => normalizeTransactionNature(subcategory.transaction_nature ?? null) === "TF"
+    );
+
+    if (!includesTransfer) {
+      normalizedSubcategories = [...normalizedSubcategories, DEFAULT_TRANSFER_CATEGORY];
+    }
   }
 
   const typedAccounts = (accounts as Account[] | null) || [];


### PR DESCRIPTION
## Summary
- load mock transaction subcategories when Supabase returns an empty list
- ensure the default transfer category is available for the fallback data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7972f9a8883298e7d2a918c4c65d2