### PR TITLE
Support server-side Supabase environment variables

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,7 +1,11 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseUrl =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL ?? null;
+const supabaseAnonKey =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+  process.env.SUPABASE_ANON_KEY ??
+  null;
 
 type SupabaseClientType = SupabaseClient | null;
 
@@ -12,8 +16,8 @@ if (supabaseUrl && supabaseAnonKey) {
   client = createClient(supabaseUrl, supabaseAnonKey);
 } else {
   const missingEnvVars = [
-    !supabaseUrl ? "NEXT_PUBLIC_SUPABASE_URL" : null,
-    !supabaseAnonKey ? "NEXT_PUBLIC_SUPABASE_ANON_KEY" : null,
+    !supabaseUrl ? "NEXT_PUBLIC_SUPABASE_URL|SUPABASE_URL" : null,
+    !supabaseAnonKey ? "NEXT_PUBLIC_SUPABASE_ANON_KEY|SUPABASE_ANON_KEY" : null,
   ].filter(Boolean);
 
   configurationError = new Error(


### PR DESCRIPTION
## Summary
- allow the Supabase client to fall back to server-only environment variables when public keys are not provided
- clarify the missing environment variable message to reflect either supported variable name

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7ac30839883299184c9d86b28eed1